### PR TITLE
configure typedoc

### DIFF
--- a/docs/Applications/README.md
+++ b/docs/Applications/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Applications
+
+# Applications
+
+## Index
+
+### Classes
+
+- [Applications](classes/Applications.md)

--- a/docs/Applications/classes/Applications.md
+++ b/docs/Applications/classes/Applications.md
@@ -1,0 +1,278 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Applications](../README.md) / Applications
+
+# Class: Applications
+
+Handles operations related to applications.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Methods
+
+### create()
+
+> **create**(`options`): `Promise`\<[`Application`](../../types/interfaces/Application.md)\>
+
+Deploy a specific task as an application
+
+#### Parameters
+
+##### options
+
+[`ApplicationCreateOptions`](../../types/interfaces/ApplicationCreateOptions.md)
+
+#### Returns
+
+`Promise`\<[`Application`](../../types/interfaces/Application.md)\>
+
+#### Example
+
+```ts
+const application = await refuel.applications.create({
+    projectId,
+    taskId,
+});
+```
+
+#### Defined in
+
+[src/Applications/index.ts:36](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Applications/index.ts#L36)
+
+***
+
+### delete()
+
+> **delete**(`applicationId`): `Promise`\<`void`\>
+
+Delete a deployed application
+
+#### Parameters
+
+##### applicationId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.applications.delete(applicationId);
+```
+
+#### Defined in
+
+[src/Applications/index.ts:88](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Applications/index.ts#L88)
+
+***
+
+### feedback()
+
+> **feedback**(`applicationId`, `itemId`, `correctLabelData`): `Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)\>
+
+Provide the correct label for an item
+
+#### Parameters
+
+##### applicationId
+
+`string`
+
+##### itemId
+
+`string`
+
+##### correctLabelData
+
+`Record`\<`string`, `string`\>
+
+#### Returns
+
+`Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)\>
+
+#### Example
+
+```ts
+const correctLabelData = {
+    vegetarian: "no",
+};
+
+await refuel.applications.feedback(
+    applicationId,
+    itemId,
+    correctLabelData,
+);
+```
+
+#### Defined in
+
+[src/Applications/index.ts:202](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Applications/index.ts#L202)
+
+***
+
+### get()
+
+> **get**(`applicationId`): `Promise`\<[`Application`](../../types/interfaces/Application.md)\>
+
+Get an application by ID
+
+#### Parameters
+
+##### applicationId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`Application`](../../types/interfaces/Application.md)\>
+
+#### Example
+
+```ts
+const application = await refuel.applications.get(applicationId);
+```
+
+#### Defined in
+
+[src/Applications/index.ts:60](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Applications/index.ts#L60)
+
+***
+
+### getLabeledItem()
+
+> **getLabeledItem**\<`FieldKeys`\>(`applicationId`, `itemId`): `Promise`\<[`ApplicationLabelResponse`](../../types/interfaces/ApplicationLabelResponse.md)\<[`ApplicationOutputSync`](../../types/interfaces/ApplicationOutputSync.md)\<`FieldKeys`\>\>\>
+
+Get labels for a specific item
+
+#### Type Parameters
+
+• **FieldKeys** *extends* `string`
+
+#### Parameters
+
+##### applicationId
+
+`string`
+
+##### itemId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`ApplicationLabelResponse`](../../types/interfaces/ApplicationLabelResponse.md)\<[`ApplicationOutputSync`](../../types/interfaces/ApplicationOutputSync.md)\<`FieldKeys`\>\>\>
+
+#### Example
+
+```ts
+const labeledItem = await refuel.applications.getLabeledItem(
+    applicationId,
+    itemId,
+);
+```
+
+#### Defined in
+
+[src/Applications/index.ts:105](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Applications/index.ts#L105)
+
+***
+
+### label()
+
+> **label**\<`FieldKeys`, `A`\>(`applicationId`, `data`, `options`?): `Promise`\<`A` *extends* `true` ? [`ApplicationLabelResponse`](../../types/interfaces/ApplicationLabelResponse.md)\<[`ApplicationOutputAsync`](../../types/interfaces/ApplicationOutputAsync.md)\> : [`ApplicationLabelResponse`](../../types/interfaces/ApplicationLabelResponse.md)\<[`ApplicationOutputSync`](../../types/interfaces/ApplicationOutputSync.md)\<`FieldKeys`\>\>\>
+
+Labels an item with your application
+
+#### Type Parameters
+
+• **FieldKeys** *extends* `string`
+
+• **A** *extends* `undefined` \| `boolean` = `undefined`
+
+#### Parameters
+
+##### applicationId
+
+`string`
+
+##### data
+
+`Record`\<`string`, `unknown`\>[]
+
+##### options?
+
+[`ApplicationLabelOptions`](../../types/interfaces/ApplicationLabelOptions.md) & `object`
+
+#### Returns
+
+`Promise`\<`A` *extends* `true` ? [`ApplicationLabelResponse`](../../types/interfaces/ApplicationLabelResponse.md)\<[`ApplicationOutputAsync`](../../types/interfaces/ApplicationOutputAsync.md)\> : [`ApplicationLabelResponse`](../../types/interfaces/ApplicationLabelResponse.md)\<[`ApplicationOutputSync`](../../types/interfaces/ApplicationOutputSync.md)\<`FieldKeys`\>\>\>
+
+#### Examples
+
+Label an item and console log the values
+```ts
+const dataToLabel = [
+    {
+        menu_text: "Grilled chicken sandwich with avocado and chipotle mayo",
+    },
+];
+
+const labeledItem = await refuel.applications.label(
+    applicationId,
+    dataToLabel,
+);
+console.log(labeledItem); // output label values
+```
+
+You can also trigger the label processing to happen asynchronously
+```ts
+const response = await refuel.applications.label(
+    applicationId,
+    dataToLabel,
+    { async: true }
+);
+
+const labeledItem = await refuel.applications.getLabeledItem(
+    response.application_id,
+    response.refuel_output[0].refuel_uuid,
+);
+
+console.log(labeledItem); // output label values
+```
+
+#### Defined in
+
+[src/Applications/index.ts:150](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Applications/index.ts#L150)
+
+***
+
+### list()
+
+> **list**(`projectId`?): `Promise`\<[`Application`](../../types/interfaces/Application.md)[]\>
+
+List all applications
+
+#### Parameters
+
+##### projectId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`Application`](../../types/interfaces/Application.md)[]\>
+
+#### Example
+
+```ts
+const applications = await refuel.applications.list();
+```
+
+#### Defined in
+
+[src/Applications/index.ts:72](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Applications/index.ts#L72)

--- a/docs/DatasetExports/README.md
+++ b/docs/DatasetExports/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / DatasetExports
+
+# DatasetExports
+
+## Index
+
+### Classes
+
+- [DatasetExports](classes/DatasetExports.md)

--- a/docs/DatasetExports/classes/DatasetExports.md
+++ b/docs/DatasetExports/classes/DatasetExports.md
@@ -1,0 +1,75 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [DatasetExports](../README.md) / DatasetExports
+
+# Class: DatasetExports
+
+Handles operations related to dataset exports.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Methods
+
+### create()
+
+> **create**(`datasetId`, `options`?): `Promise`\<[`ExportDatasetResponse`](../../types/interfaces/ExportDatasetResponse.md)\>
+
+Email a secure, expiring link to download a dataset
+
+#### Parameters
+
+##### datasetId
+
+`string`
+
+##### options?
+
+[`ExportDatasetOptions`](../../types/interfaces/ExportDatasetOptions.md)
+
+#### Returns
+
+`Promise`\<[`ExportDatasetResponse`](../../types/interfaces/ExportDatasetResponse.md)\>
+
+#### Example
+
+```ts
+const export = await refuel.datasetExports.create(datasetId, { email: "example@example.com" });
+```
+
+#### Defined in
+
+[src/DatasetExports/index.ts:39](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/DatasetExports/index.ts#L39)
+
+***
+
+### get()
+
+> **get**(`exportId`, `datasetId`): `Promise`\<`string`\>
+
+Get the URL of a dataset export
+
+#### Parameters
+
+##### exportId
+
+`string`
+
+##### datasetId
+
+`string`
+
+#### Returns
+
+`Promise`\<`string`\>
+
+#### Example
+
+```ts
+const export = await refuel.datasetExports.get(exportId, datasetId);
+```
+
+#### Defined in
+
+[src/DatasetExports/index.ts:25](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/DatasetExports/index.ts#L25)

--- a/docs/DatasetItems/README.md
+++ b/docs/DatasetItems/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / DatasetItems
+
+# DatasetItems
+
+## Index
+
+### Classes
+
+- [DatasetItems](classes/DatasetItems.md)

--- a/docs/DatasetItems/classes/DatasetItems.md
+++ b/docs/DatasetItems/classes/DatasetItems.md
@@ -1,0 +1,127 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [DatasetItems](../README.md) / DatasetItems
+
+# Class: DatasetItems
+
+## Methods
+
+### create()
+
+> **create**(`datasetId`, `data`): `Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)\>
+
+Add data to a dataset
+
+#### Parameters
+
+##### datasetId
+
+`string`
+
+##### data
+
+`Record`\<`string`, `unknown`\>[]
+
+#### Returns
+
+`Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)\>
+
+#### Example
+
+```ts
+const dataset = await refuel.datasetItems.create(datasetId, [{ "name": "John Doe" }, { "name": "Jane Doe" }]);
+```
+
+#### Defined in
+
+[src/DatasetItems/index.ts:20](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/DatasetItems/index.ts#L20)
+
+***
+
+### delete()
+
+> **delete**(`datasetId`, `itemId`): `Promise`\<`void`\>
+
+Delete a dataset item
+
+#### Parameters
+
+##### datasetId
+
+`string`
+
+##### itemId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.datasetItems.delete(datasetId, itemId);
+```
+
+#### Defined in
+
+[src/DatasetItems/index.ts:88](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/DatasetItems/index.ts#L88)
+
+***
+
+### get()
+
+> **get**(`datasetId`, `itemId`): `Promise`\<`Record`\<`string`, `string`\>\>
+
+Get a dataset item by ID
+
+#### Parameters
+
+##### datasetId
+
+`string`
+
+##### itemId
+
+`string`
+
+#### Returns
+
+`Promise`\<`Record`\<`string`, `string`\>\>
+
+#### Example
+
+```ts
+const item = await refuel.datasetItems.get(datasetId, itemId);
+```
+
+#### Defined in
+
+[src/DatasetItems/index.ts:38](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/DatasetItems/index.ts#L38)
+
+***
+
+### list()
+
+> **list**(`datasetId`, `options`?): `Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)[]\>
+
+#### Parameters
+
+##### datasetId
+
+`string`
+
+##### options?
+
+[`DatasetItemsOptions`](../../types/interfaces/DatasetItemsOptions.md)
+
+#### Returns
+
+`Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)[]\>
+
+#### Defined in
+
+[src/DatasetItems/index.ts:49](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/DatasetItems/index.ts#L49)

--- a/docs/Datasets/README.md
+++ b/docs/Datasets/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Datasets
+
+# Datasets
+
+## Index
+
+### Classes
+
+- [Datasets](classes/Datasets.md)

--- a/docs/Datasets/classes/Datasets.md
+++ b/docs/Datasets/classes/Datasets.md
@@ -1,0 +1,95 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Datasets](../README.md) / Datasets
+
+# Class: Datasets
+
+Handles operations related to datasets.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Methods
+
+### delete()
+
+> **delete**(`datasetId`): `Promise`\<`void`\>
+
+Delete a dataset
+
+#### Parameters
+
+##### datasetId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.datasets.delete(datasetId);
+```
+
+#### Defined in
+
+[src/Datasets/index.ts:57](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Datasets/index.ts#L57)
+
+***
+
+### get()
+
+> **get**(`datasetId`): `Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)\>
+
+Get a dataset by ID
+
+#### Parameters
+
+##### datasetId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`Dataset`](../../types/interfaces/Dataset.md)\>
+
+#### Example
+
+```ts
+const dataset = await refuel.datasets.get(datasetId);
+```
+
+#### Defined in
+
+[src/Datasets/index.ts:25](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Datasets/index.ts#L25)
+
+***
+
+### list()
+
+> **list**(`projectId`?): `Promise`\<[`DatasetFromList`](../../types/interfaces/DatasetFromList.md)[]\>
+
+List all datasets
+
+#### Parameters
+
+##### projectId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`DatasetFromList`](../../types/interfaces/DatasetFromList.md)[]\>
+
+#### Example
+
+```ts
+const datasets = await refuel.datasets.list();
+```
+
+#### Defined in
+
+[src/Datasets/index.ts:37](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Datasets/index.ts#L37)

--- a/docs/FinetunedModels/README.md
+++ b/docs/FinetunedModels/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / FinetunedModels
+
+# FinetunedModels
+
+## Index
+
+### Classes
+
+- [FinetunedModels](classes/FinetunedModels.md)

--- a/docs/FinetunedModels/classes/FinetunedModels.md
+++ b/docs/FinetunedModels/classes/FinetunedModels.md
@@ -1,0 +1,159 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [FinetunedModels](../README.md) / FinetunedModels
+
+# Class: FinetunedModels
+
+## Methods
+
+### create()
+
+> **create**(`data`): `Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)\>
+
+Create a new finetuned model
+
+#### Parameters
+
+##### data
+
+[`FinetunedModelCreateOptions`](../../types/type-aliases/FinetunedModelCreateOptions.md)
+
+#### Returns
+
+`Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)\>
+
+#### Example
+
+```ts
+const model = await refuel.finetunedModels.create({
+    project_id: "c4a7d428-3c8d-4e39-b887-6f3ad8d23f1c",
+    task_id: "9b2e7f15-6d4a-4c31-b518-3a69e0f98d42",
+    datasets: ["c4a7d428-3c8d-4e39-b887-6f3ad8d23f1c"],
+    base_model: "refuel-llm-2-large",
+    augmented_finetuning_model: "gpt-4o",
+    hyperparameters: {
+        learning_rate_multiplier: 20,
+        num_epochs: 10,
+        lora_r: 32,
+    },
+    lora: true,
+});
+```
+
+#### Defined in
+
+[src/FinetunedModels/index.ts:32](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/FinetunedModels/index.ts#L32)
+
+***
+
+### delete()
+
+> **delete**(`modelId`): `Promise`\<`void`\>
+
+Delete a finetuned model
+
+#### Parameters
+
+##### modelId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.finetunedModels.delete(modelId);
+```
+
+#### Defined in
+
+[src/FinetunedModels/index.ts:94](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/FinetunedModels/index.ts#L94)
+
+***
+
+### get()
+
+> **get**(`modelId`): `Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)\>
+
+Get a finetuned model by ID
+
+#### Parameters
+
+##### modelId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)\>
+
+#### Example
+
+```ts
+const model = await refuel.finetunedModels.get(modelId);
+```
+
+#### Defined in
+
+[src/FinetunedModels/index.ts:50](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/FinetunedModels/index.ts#L50)
+
+***
+
+### list()
+
+> **list**(`projectId`, `taskId`?): `Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)[]\>
+
+List all finetuned models for a project or task
+
+#### Parameters
+
+##### projectId
+
+`string`
+
+##### taskId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)[]\>
+
+#### Example
+
+```ts
+const models = await refuel.finetunedModels.list(projectId);
+```
+
+#### Defined in
+
+[src/FinetunedModels/index.ts:62](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/FinetunedModels/index.ts#L62)
+
+***
+
+### update()
+
+> **update**(`modelId`, `data`): `Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)\>
+
+#### Parameters
+
+##### modelId
+
+`string`
+
+##### data
+
+`Partial`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)\>
+
+#### Returns
+
+`Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)\>
+
+#### Defined in
+
+[src/FinetunedModels/index.ts:73](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/FinetunedModels/index.ts#L73)

--- a/docs/Integrations/README.md
+++ b/docs/Integrations/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Integrations
+
+# Integrations
+
+## Index
+
+### Classes
+
+- [Integrations](classes/Integrations.md)

--- a/docs/Integrations/classes/Integrations.md
+++ b/docs/Integrations/classes/Integrations.md
@@ -1,0 +1,113 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Integrations](../README.md) / Integrations
+
+# Class: Integrations
+
+Handles operations related to third party integrations.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new Integrations()
+
+> **new Integrations**(`base`): [`Integrations`](Integrations.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Integrations`](Integrations.md)
+
+#### Defined in
+
+[src/Integrations/index.ts:12](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Integrations/index.ts#L12)
+
+## Methods
+
+### get()
+
+> **get**(`integrationId`): `Promise`\<[`Integration`](../../types/interfaces/Integration.md)\>
+
+Get a third party integration by ID
+
+#### Parameters
+
+##### integrationId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`Integration`](../../types/interfaces/Integration.md)\>
+
+#### Example
+
+```ts
+const integration = await refuel.integrations.get(integrationId);
+```
+
+#### Defined in
+
+[src/Integrations/index.ts:24](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Integrations/index.ts#L24)
+
+***
+
+### list()
+
+> **list**(): `Promise`\<[`Integration`](../../types/interfaces/Integration.md)[]\>
+
+List all third party integrations
+
+#### Returns
+
+`Promise`\<[`Integration`](../../types/interfaces/Integration.md)[]\>
+
+#### Example
+
+```ts
+const integrations = await refuel.integrations.list();
+```
+
+#### Defined in
+
+[src/Integrations/index.ts:36](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Integrations/index.ts#L36)
+
+***
+
+### update()
+
+> **update**(`integrationId`, `data`): `Promise`\<[`Integration`](../../types/interfaces/Integration.md)\>
+
+Update a third party integration
+
+#### Parameters
+
+##### integrationId
+
+`string`
+
+##### data
+
+`Partial`\<[`Integration`](../../types/interfaces/Integration.md)\>
+
+#### Returns
+
+`Promise`\<[`Integration`](../../types/interfaces/Integration.md)\>
+
+#### Example
+
+```ts
+const integration = await refuel.integrations.update(integrationId, { is_connected: false });
+```
+
+#### Defined in
+
+[src/Integrations/index.ts:48](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Integrations/index.ts#L48)

--- a/docs/Labels/README.md
+++ b/docs/Labels/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Labels
+
+# Labels
+
+## Index
+
+### Classes
+
+- [Labels](classes/Labels.md)

--- a/docs/Labels/classes/Labels.md
+++ b/docs/Labels/classes/Labels.md
@@ -1,0 +1,195 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Labels](../README.md) / Labels
+
+# Class: Labels
+
+Handles operations related to labels.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new Labels()
+
+> **new Labels**(`base`): [`Labels`](Labels.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Labels`](Labels.md)
+
+#### Defined in
+
+[src/Labels/index.ts:17](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Labels/index.ts#L17)
+
+## Methods
+
+### approve()
+
+> **approve**(`taskId`, `datasetId`, `itemId`, `options`?): `Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+Approve labels for a dataset item
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### datasetId
+
+`string`
+
+##### itemId
+
+`string`
+
+##### options?
+
+###### modelId
+
+`string`
+
+###### subtaskId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+#### Example
+
+```ts
+const labels = await refuel.labels.approve(taskId, datasetId, itemId, subtaskId);
+```
+
+#### Defined in
+
+[src/Labels/index.ts:109](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Labels/index.ts#L109)
+
+***
+
+### generateExplanations()
+
+> **generateExplanations**(`taskId`, `datasetId`, `itemId`, `options`?): `Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### datasetId
+
+`string`
+
+##### itemId
+
+`string`
+
+##### options?
+
+###### modelId
+
+`string`
+
+###### subtaskId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+#### Defined in
+
+[src/Labels/index.ts:144](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Labels/index.ts#L144)
+
+***
+
+### list()
+
+> **list**(`taskId`, `datasetId`, `itemId`, `options`?): `Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+List all labels for a dataset item
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### datasetId
+
+`string`
+
+##### itemId
+
+`string`
+
+##### options?
+
+[`LabelListOptions`](../../types/interfaces/LabelListOptions.md)
+
+#### Returns
+
+`Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+#### Example
+
+```ts
+const labels = await refuel.labels.list(taskId, datasetId, itemId);
+```
+
+#### Defined in
+
+[src/Labels/index.ts:39](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Labels/index.ts#L39)
+
+***
+
+### update()
+
+> **update**(`taskId`, `datasetId`, `itemId`, `labels`): `Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+Update labels for a dataset item
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### datasetId
+
+`string`
+
+##### itemId
+
+`string`
+
+##### labels
+
+[`DatasetItemLabelsUpdate`](../../types/interfaces/DatasetItemLabelsUpdate.md)
+
+#### Returns
+
+`Promise`\<[`DatasetItemLabels`](../../types/interfaces/DatasetItemLabels.md)\>
+
+#### Example
+
+```ts
+const labels = await refuel.labels.update(taskId, datasetId, itemId, { "subtask_id": "label_value" });
+```
+
+#### Defined in
+
+[src/Labels/index.ts:84](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Labels/index.ts#L84)

--- a/docs/Projects/README.md
+++ b/docs/Projects/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Projects
+
+# Projects
+
+## Index
+
+### Classes
+
+- [Projects](classes/Projects.md)

--- a/docs/Projects/classes/Projects.md
+++ b/docs/Projects/classes/Projects.md
@@ -1,0 +1,139 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Projects](../README.md) / Projects
+
+# Class: Projects
+
+Handles operations related to projects.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new Projects()
+
+> **new Projects**(`base`): [`Projects`](Projects.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Projects`](Projects.md)
+
+#### Defined in
+
+[src/Projects/index.ts:12](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Projects/index.ts#L12)
+
+## Methods
+
+### create()
+
+> **create**(`data`): `Promise`\<[`Project`](../../types/interfaces/Project.md)\>
+
+Create a new project
+
+#### Parameters
+
+##### data
+
+[`ProjectData`](../../types/interfaces/ProjectData.md)
+
+#### Returns
+
+`Promise`\<[`Project`](../../types/interfaces/Project.md)\>
+
+#### Example
+
+```ts
+const project = await refuel.projects.create({
+    project_name: "My Project",
+});
+```
+
+#### Defined in
+
+[src/Projects/index.ts:26](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Projects/index.ts#L26)
+
+***
+
+### delete()
+
+> **delete**(`projectId`): `Promise`\<`void`\>
+
+Delete a project and all associated resources
+
+#### Parameters
+
+##### projectId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.projects.delete(projectId);
+```
+
+#### Defined in
+
+[src/Projects/index.ts:69](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Projects/index.ts#L69)
+
+***
+
+### get()
+
+> **get**(`projectId`): `Promise`\<[`Project`](../../types/interfaces/Project.md)\>
+
+Get a project by ID
+
+#### Parameters
+
+##### projectId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`Project`](../../types/interfaces/Project.md)\>
+
+#### Example
+
+```ts
+const project = await refuel.projects.get(projectId);
+```
+
+#### Defined in
+
+[src/Projects/index.ts:45](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Projects/index.ts#L45)
+
+***
+
+### list()
+
+> **list**(): `Promise`\<[`Project`](../../types/interfaces/Project.md)[]\>
+
+List all projects
+
+#### Returns
+
+`Promise`\<[`Project`](../../types/interfaces/Project.md)[]\>
+
+#### Example
+
+```ts
+const projects = await refuel.projects.list();
+```
+
+#### Defined in
+
+[src/Projects/index.ts:57](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Projects/index.ts#L57)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,69 @@
+**refuel-sdk**
+
+***
+
+# Refuel JavaScript SDK
+
+The Refuel JavaScript SDK is a lightweight and easy-to-use client library for interacting with the [Refuel API](https://cloud-api.refuel.ai/docs). It enables you to label data, manage application responses, and collect feedback seamlessly within your JavaScript or TypeScript applications.
+
+_Note: We also have a [SDK for Python](https://docs.refuel.ai/python-sdk/)._
+
+# 📦 Installation
+
+To install the SDK, use npm or yarn:
+
+```sh
+npm install refuel-sdk
+```
+
+or
+
+```sh
+yarn add refuel-sdk
+```
+
+# 🧑‍💻 Usage
+
+To get started, you'll need a Refuel API key. You can find this in your [account settings](https://app.refuel.ai/settings) or contact your team administrator.
+
+Import the SDK into your application and start interacting with the Refuel API:
+
+## Example: Label Data
+
+```javascript
+import { Refuel } from "refuel-sdk";
+
+const refuel = new Refuel("your_access_token");
+
+const applicationLabels = await refuel.applications.label(
+    "your_application_id",
+    [
+        // Data to label
+        {
+            menu_text:
+                "Grilled chicken sandwich with avocado and chipotle mayo",
+        },
+    ]
+);
+```
+
+## Example: Update Label with Feedback
+
+```javascript
+import { Refuel } from "refuel-sdk";
+
+const refuel = new Refuel("your_access_token");
+
+await refuel.applications.feedback(
+    "your_application_id",
+    "your_labeled_item_id",
+    // Correct label
+    {
+        vegetarian: "no",
+    }
+);
+```
+
+# Questions?
+
+Reach out to us at support@refuel.ai with any questions!

--- a/docs/RefuelBase/README.md
+++ b/docs/RefuelBase/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / RefuelBase
+
+# RefuelBase
+
+## Index
+
+### Classes
+
+- [RefuelAPIError](classes/RefuelAPIError.md)

--- a/docs/RefuelBase/classes/RefuelAPIError.md
+++ b/docs/RefuelBase/classes/RefuelAPIError.md
@@ -1,0 +1,193 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [RefuelBase](../README.md) / RefuelAPIError
+
+# Class: RefuelAPIError
+
+## Extends
+
+- `Error`
+
+## Constructors
+
+### new RefuelAPIError()
+
+> **new RefuelAPIError**(`response`?, `url`?, `status`?): [`RefuelAPIError`](RefuelAPIError.md)
+
+#### Parameters
+
+##### response?
+
+`Response`
+
+##### url?
+
+`undefined` | `string`
+
+##### status?
+
+`undefined` | `number`
+
+#### Returns
+
+[`RefuelAPIError`](RefuelAPIError.md)
+
+#### Overrides
+
+`Error.constructor`
+
+#### Defined in
+
+[src/RefuelBase/index.ts:10](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/RefuelBase/index.ts#L10)
+
+## Properties
+
+### message
+
+> **message**: `string`
+
+#### Inherited from
+
+`Error.message`
+
+#### Defined in
+
+node\_modules/typescript/lib/lib.es5.d.ts:1077
+
+***
+
+### name
+
+> **name**: `string`
+
+#### Inherited from
+
+`Error.name`
+
+#### Defined in
+
+node\_modules/typescript/lib/lib.es5.d.ts:1076
+
+***
+
+### response?
+
+> `readonly` `optional` **response**: `Response`
+
+#### Defined in
+
+[src/RefuelBase/index.ts:11](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/RefuelBase/index.ts#L11)
+
+***
+
+### stack?
+
+> `optional` **stack**: `string`
+
+#### Inherited from
+
+`Error.stack`
+
+#### Defined in
+
+node\_modules/typescript/lib/lib.es5.d.ts:1078
+
+***
+
+### status
+
+> `readonly` **status**: `undefined` \| `number` = `response.status`
+
+#### Defined in
+
+[src/RefuelBase/index.ts:13](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/RefuelBase/index.ts#L13)
+
+***
+
+### url
+
+> `readonly` **url**: `undefined` \| `string` = `response.url`
+
+#### Defined in
+
+[src/RefuelBase/index.ts:12](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/RefuelBase/index.ts#L12)
+
+***
+
+### prepareStackTrace()?
+
+> `static` `optional` **prepareStackTrace**: (`err`, `stackTraces`) => `any`
+
+Optional override for formatting stack traces
+
+#### Parameters
+
+##### err
+
+`Error`
+
+##### stackTraces
+
+`CallSite`[]
+
+#### Returns
+
+`any`
+
+#### See
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+#### Inherited from
+
+`Error.prepareStackTrace`
+
+#### Defined in
+
+node\_modules/@types/node/globals.d.ts:143
+
+***
+
+### stackTraceLimit
+
+> `static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+`Error.stackTraceLimit`
+
+#### Defined in
+
+node\_modules/@types/node/globals.d.ts:145
+
+## Methods
+
+### captureStackTrace()
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+##### targetObject
+
+`object`
+
+##### constructorOpt?
+
+`Function`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Error.captureStackTrace`
+
+#### Defined in
+
+node\_modules/@types/node/globals.d.ts:136

--- a/docs/TaskModels/README.md
+++ b/docs/TaskModels/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / TaskModels
+
+# TaskModels
+
+## Index
+
+### Classes
+
+- [TaskModels](classes/TaskModels.md)

--- a/docs/TaskModels/classes/TaskModels.md
+++ b/docs/TaskModels/classes/TaskModels.md
@@ -1,0 +1,59 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [TaskModels](../README.md) / TaskModels
+
+# Class: TaskModels
+
+Handles operations related to labeling models.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new TaskModels()
+
+> **new TaskModels**(`base`): [`TaskModels`](TaskModels.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`TaskModels`](TaskModels.md)
+
+#### Defined in
+
+[src/TaskModels/index.ts:12](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaskModels/index.ts#L12)
+
+## Methods
+
+### list()
+
+> **list**(`taskId`): `Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)[]\>
+
+List all models available for a task
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`LabelingModel`](../../types/interfaces/LabelingModel.md)[]\>
+
+#### Example
+
+```ts
+const models = await refuel.taskModels.list(taskId);
+```
+
+#### Defined in
+
+[src/TaskModels/index.ts:24](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaskModels/index.ts#L24)

--- a/docs/TaskRuns/README.md
+++ b/docs/TaskRuns/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / TaskRuns
+
+# TaskRuns
+
+## Index
+
+### Classes
+
+- [TaskRuns](classes/TaskRuns.md)

--- a/docs/TaskRuns/classes/TaskRuns.md
+++ b/docs/TaskRuns/classes/TaskRuns.md
@@ -1,0 +1,127 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [TaskRuns](../README.md) / TaskRuns
+
+# Class: TaskRuns
+
+Handles operations related to task runs.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new TaskRuns()
+
+> **new TaskRuns**(`base`): [`TaskRuns`](TaskRuns.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`TaskRuns`](TaskRuns.md)
+
+#### Defined in
+
+[src/TaskRuns/index.ts:17](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaskRuns/index.ts#L17)
+
+## Methods
+
+### cancel()
+
+> **cancel**(`taskId`, `options`): `Promise`\<`void`\>
+
+Cancel a task run
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### options
+
+[`TaskRunCancelOptions`](../../types/interfaces/TaskRunCancelOptions.md)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.taskRuns.cancel(taskId, { datasetId });
+```
+
+#### Defined in
+
+[src/TaskRuns/index.ts:76](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaskRuns/index.ts#L76)
+
+***
+
+### create()
+
+> **create**(`taskId`, `options`?): `Promise`\<[`TaskRun`](../../types/interfaces/TaskRun.md)\>
+
+Create a task run
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### options?
+
+[`TaskRunCreateOptions`](../../types/interfaces/TaskRunCreateOptions.md)
+
+#### Returns
+
+`Promise`\<[`TaskRun`](../../types/interfaces/TaskRun.md)\>
+
+#### Example
+
+```ts
+const taskRun = await refuel.taskRuns.create(taskId, { datasetId });
+```
+
+#### Defined in
+
+[src/TaskRuns/index.ts:29](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaskRuns/index.ts#L29)
+
+***
+
+### list()
+
+> **list**(`taskId`, `options`?): `Promise`\<[`TaskRun`](../../types/interfaces/TaskRun.md)[]\>
+
+List all task runs
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### options?
+
+[`TaskRunListOptions`](../../types/interfaces/TaskRunListOptions.md)
+
+#### Returns
+
+`Promise`\<[`TaskRun`](../../types/interfaces/TaskRun.md)[]\>
+
+#### Example
+
+```ts
+const taskRuns = await refuel.taskRuns.list(taskId);
+```
+
+#### Defined in
+
+[src/TaskRuns/index.ts:106](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaskRuns/index.ts#L106)

--- a/docs/Tasks/README.md
+++ b/docs/Tasks/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Tasks
+
+# Tasks
+
+## Index
+
+### Classes
+
+- [Tasks](classes/Tasks.md)

--- a/docs/Tasks/classes/Tasks.md
+++ b/docs/Tasks/classes/Tasks.md
@@ -1,0 +1,147 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Tasks](../README.md) / Tasks
+
+# Class: Tasks
+
+Handles operations related to tasks.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new Tasks()
+
+> **new Tasks**(`base`): [`Tasks`](Tasks.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Tasks`](Tasks.md)
+
+#### Defined in
+
+[src/Tasks/index.ts:12](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Tasks/index.ts#L12)
+
+## Methods
+
+### delete()
+
+> **delete**(`taskId`): `Promise`\<`void`\>
+
+Delete a task
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.tasks.delete(taskId);
+```
+
+#### Defined in
+
+[src/Tasks/index.ts:65](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Tasks/index.ts#L65)
+
+***
+
+### get()
+
+> **get**(`taskId`): `Promise`\<[`Task`](../../types/interfaces/Task.md)\>
+
+Get a task by ID
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`Task`](../../types/interfaces/Task.md)\>
+
+#### Example
+
+```ts
+const task = await refuel.tasks.get(taskId);
+```
+
+#### Defined in
+
+[src/Tasks/index.ts:24](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Tasks/index.ts#L24)
+
+***
+
+### list()
+
+> **list**(`projectId`?): `Promise`\<[`Tasks`](Tasks.md)[]\>
+
+List all tasks
+
+#### Parameters
+
+##### projectId?
+
+`string`
+
+#### Returns
+
+`Promise`\<[`Tasks`](Tasks.md)[]\>
+
+#### Example
+
+```ts
+const tasks = await refuel.tasks.list();
+```
+
+#### Defined in
+
+[src/Tasks/index.ts:36](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Tasks/index.ts#L36)
+
+***
+
+### update()
+
+> **update**(`taskId`, `data`): `Promise`\<[`Task`](../../types/interfaces/Task.md)\>
+
+Update a task
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### data
+
+`Partial`\<[`Task`](../../types/interfaces/Task.md)\>
+
+#### Returns
+
+`Promise`\<[`Task`](../../types/interfaces/Task.md)\>
+
+#### Example
+
+```ts
+const task = await refuel.tasks.update(taskId, { name: "New Name" });
+```
+
+#### Defined in
+
+[src/Tasks/index.ts:50](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Tasks/index.ts#L50)

--- a/docs/Taxonomies/README.md
+++ b/docs/Taxonomies/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Taxonomies
+
+# Taxonomies
+
+## Index
+
+### Classes
+
+- [Taxonomies](classes/Taxonomies.md)

--- a/docs/Taxonomies/classes/Taxonomies.md
+++ b/docs/Taxonomies/classes/Taxonomies.md
@@ -1,0 +1,154 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Taxonomies](../README.md) / Taxonomies
+
+# Class: Taxonomies
+
+Handles operations related to taxonomies.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new Taxonomies()
+
+> **new Taxonomies**(`base`): [`Taxonomies`](Taxonomies.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Taxonomies`](Taxonomies.md)
+
+#### Defined in
+
+[src/Taxonomies/index.ts:16](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Taxonomies/index.ts#L16)
+
+## Methods
+
+### create()
+
+> **create**(`taskId`, `labels`): `Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+Create a taxonomy for a task
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### labels
+
+[`TaxonomyLabelData`](../../types/interfaces/TaxonomyLabelData.md) | [`TaxonomyLabelData`](../../types/interfaces/TaxonomyLabelData.md)[]
+
+#### Returns
+
+`Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+#### Example
+
+```ts
+const taxonomy = await refuel.taxonomies.create(taskId, [
+ { name: "Label 1" },
+ { name: "Label 2" },
+]);
+```
+
+#### Defined in
+
+[src/Taxonomies/index.ts:31](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Taxonomies/index.ts#L31)
+
+***
+
+### delete()
+
+> **delete**(`taskId`, `taxonomyId`): `Promise`\<`void`\>
+
+Delete a taxonomy
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### taxonomyId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.taxonomies.delete(taskId, taxonomyId);
+```
+
+#### Defined in
+
+[src/Taxonomies/index.ts:62](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Taxonomies/index.ts#L62)
+
+***
+
+### duplicate()
+
+> **duplicate**(`taskId`, `taxonomyId`): `Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+Create a duplicate of an existing taxonomy
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### taxonomyId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+#### Example
+
+```ts
+const taxonomy = await refuel.taxonomies.duplicate(taskId, taxonomyId);
+```
+
+#### Defined in
+
+[src/Taxonomies/index.ts:79](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Taxonomies/index.ts#L79)
+
+***
+
+### get()
+
+> **get**(`taskId`, `taxonomyId`): `Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### taxonomyId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+#### Defined in
+
+[src/Taxonomies/index.ts:48](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Taxonomies/index.ts#L48)

--- a/docs/TaxonomyLabels/README.md
+++ b/docs/TaxonomyLabels/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / TaxonomyLabels
+
+# TaxonomyLabels
+
+## Index
+
+### Classes
+
+- [TaxonomyLabels](classes/TaxonomyLabels.md)

--- a/docs/TaxonomyLabels/classes/TaxonomyLabels.md
+++ b/docs/TaxonomyLabels/classes/TaxonomyLabels.md
@@ -1,0 +1,192 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [TaxonomyLabels](../README.md) / TaxonomyLabels
+
+# Class: TaxonomyLabels
+
+Handles operations related to taxonomy labels.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new TaxonomyLabels()
+
+> **new TaxonomyLabels**(`base`): [`TaxonomyLabels`](TaxonomyLabels.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`TaxonomyLabels`](TaxonomyLabels.md)
+
+#### Defined in
+
+[src/TaxonomyLabels/index.ts:16](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaxonomyLabels/index.ts#L16)
+
+## Methods
+
+### create()
+
+> **create**(`taskId`, `taxonomyId`, `labels`): `Promise`\<`void`\>
+
+Add labels to a taxonomy
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### taxonomyId
+
+`string`
+
+##### labels
+
+[`TaxonomyLabelData`](../../types/interfaces/TaxonomyLabelData.md) | [`TaxonomyLabelData`](../../types/interfaces/TaxonomyLabelData.md)[]
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+const label = await refuel.taxonomyLabels.create(taskId, taxonomyId, [
+ { name: "Label 1" },
+ { name: "Label 2" },
+]);
+```
+
+#### Defined in
+
+[src/TaxonomyLabels/index.ts:31](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaxonomyLabels/index.ts#L31)
+
+***
+
+### delete()
+
+> **delete**(`taskId`, `taxonomyId`, `labelId`): `Promise`\<`void`\>
+
+Delete a label from a taxonomy
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### taxonomyId
+
+`string`
+
+##### labelId
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Example
+
+```ts
+await refuel.taxonomyLabels.delete(taskId, taxonomyId, labelId);
+```
+
+#### Defined in
+
+[src/TaxonomyLabels/index.ts:119](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaxonomyLabels/index.ts#L119)
+
+***
+
+### list()
+
+> **list**(`taskId`, `taxonomyId`, `options`?): `Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+List all labels in a taxonomy
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### taxonomyId
+
+`string`
+
+##### options?
+
+###### filter
+
+`string`
+
+###### maxItems
+
+`number`
+
+###### offset
+
+`number`
+
+#### Returns
+
+`Promise`\<[`TaxonomyLabelsResponse`](../../types/interfaces/TaxonomyLabelsResponse.md)\>
+
+#### Example
+
+```ts
+const labels = await refuel.taxonomyLabels.list(taskId, taxonomyId);
+```
+
+#### Defined in
+
+[src/TaxonomyLabels/index.ts:60](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaxonomyLabels/index.ts#L60)
+
+***
+
+### update()
+
+> **update**(`taskId`, `taxonomyId`, `labelId`, `data`): `Promise`\<[`TaxonomyLabel`](../../types/interfaces/TaxonomyLabel.md)\>
+
+Update a label in a taxonomy
+
+#### Parameters
+
+##### taskId
+
+`string`
+
+##### taxonomyId
+
+`string`
+
+##### labelId
+
+`string`
+
+##### data
+
+`Partial`\<[`TaxonomyLabelData`](../../types/interfaces/TaxonomyLabelData.md)\>
+
+#### Returns
+
+`Promise`\<[`TaxonomyLabel`](../../types/interfaces/TaxonomyLabel.md)\>
+
+#### Example
+
+```ts
+const label = await refuel.taxonomyLabels.update(taskId, taxonomyId, labelId, { name: "New Name" });
+```
+
+#### Defined in
+
+[src/TaxonomyLabels/index.ts:96](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TaxonomyLabels/index.ts#L96)

--- a/docs/Team/README.md
+++ b/docs/Team/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Team
+
+# Team
+
+## Index
+
+### Classes
+
+- [Team](classes/Team.md)

--- a/docs/Team/classes/Team.md
+++ b/docs/Team/classes/Team.md
@@ -1,0 +1,99 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Team](../README.md) / Team
+
+# Class: Team
+
+## Constructors
+
+### new Team()
+
+> **new Team**(`base`): [`Team`](Team.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Team`](Team.md)
+
+#### Defined in
+
+[src/Team/index.ts:7](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Team/index.ts#L7)
+
+## Methods
+
+### get()
+
+> **get**(): `Promise`\<[`RefuelTeam`](../../types/interfaces/RefuelTeam.md)\>
+
+Get the current team
+
+#### Returns
+
+`Promise`\<[`RefuelTeam`](../../types/interfaces/RefuelTeam.md)\>
+
+#### Example
+
+```ts
+const team = await refuel.team.get();
+```
+
+#### Defined in
+
+[src/Team/index.ts:19](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Team/index.ts#L19)
+
+***
+
+### regenerateApiKey()
+
+> **regenerateApiKey**(): `Promise`\<`string`\>
+
+Regenerate the API key for the current team
+
+#### Returns
+
+`Promise`\<`string`\>
+
+#### Example
+
+```ts
+const apiKey = await refuel.team.regenerateApiKey();
+```
+
+#### Defined in
+
+[src/Team/index.ts:31](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Team/index.ts#L31)
+
+***
+
+### signUrl()
+
+> **signUrl**(`url`): `Promise`\<\{ `url`: `string`; \}\>
+
+Sign a URL
+
+#### Parameters
+
+##### url
+
+`string`
+
+#### Returns
+
+`Promise`\<\{ `url`: `string`; \}\>
+
+#### Example
+
+```ts
+const signedUrl = await refuel.team.signUrl("https://example.com");
+```
+
+#### Defined in
+
+[src/Team/index.ts:50](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Team/index.ts#L50)

--- a/docs/TeamModels/README.md
+++ b/docs/TeamModels/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / TeamModels
+
+# TeamModels
+
+## Index
+
+### Classes
+
+- [TeamModels](classes/TeamModels.md)

--- a/docs/TeamModels/classes/TeamModels.md
+++ b/docs/TeamModels/classes/TeamModels.md
@@ -1,0 +1,41 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [TeamModels](../README.md) / TeamModels
+
+# Class: TeamModels
+
+## Constructors
+
+### new TeamModels()
+
+> **new TeamModels**(`base`): [`TeamModels`](TeamModels.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`TeamModels`](TeamModels.md)
+
+#### Defined in
+
+[src/TeamModels/index.ts:7](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TeamModels/index.ts#L7)
+
+## Methods
+
+### list()
+
+> **list**(): `Promise`\<[`TeamModel`](../../types/interfaces/TeamModel.md)[]\>
+
+#### Returns
+
+`Promise`\<[`TeamModel`](../../types/interfaces/TeamModel.md)[]\>
+
+#### Defined in
+
+[src/TeamModels/index.ts:11](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/TeamModels/index.ts#L11)

--- a/docs/Usage/README.md
+++ b/docs/Usage/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Usage
+
+# Usage
+
+## Index
+
+### Classes
+
+- [Usage](classes/Usage.md)

--- a/docs/Usage/classes/Usage.md
+++ b/docs/Usage/classes/Usage.md
@@ -1,0 +1,73 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Usage](../README.md) / Usage
+
+# Class: Usage
+
+## Constructors
+
+### new Usage()
+
+> **new Usage**(`base`): [`Usage`](Usage.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Usage`](Usage.md)
+
+#### Defined in
+
+[src/Usage/index.ts:7](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Usage/index.ts#L7)
+
+## Methods
+
+### get()
+
+> **get**(`startDate`, `endDate`, `options`?): `Promise`\<[`UsageData`](../../types/type-aliases/UsageData.md)\>
+
+Get usage data for a specific time period
+
+#### Parameters
+
+##### startDate
+
+`string`
+
+##### endDate
+
+`string`
+
+##### options?
+
+###### applicationId
+
+`string`
+
+###### modelId
+
+`string`
+
+###### taskId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`UsageData`](../../types/type-aliases/UsageData.md)\>
+
+#### Example
+
+```ts
+const usage = await refuel.usage.get("2024-01-01", "2024-01-31");
+```
+
+#### Defined in
+
+[src/Usage/index.ts:19](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Usage/index.ts#L19)

--- a/docs/Users/README.md
+++ b/docs/Users/README.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / Users
+
+# Users
+
+## Index
+
+### Classes
+
+- [Users](classes/Users.md)

--- a/docs/Users/classes/Users.md
+++ b/docs/Users/classes/Users.md
@@ -1,0 +1,109 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [Users](../README.md) / Users
+
+# Class: Users
+
+Handles operations related to users.
+This class is not intended to be instantiated directly.
+Instead, access it through an instance of the Refuel class.
+
+## Constructors
+
+### new Users()
+
+> **new Users**(`base`): [`Users`](Users.md)
+
+#### Parameters
+
+##### base
+
+`RefuelBase`
+
+#### Returns
+
+[`Users`](Users.md)
+
+#### Defined in
+
+[src/Users/index.ts:12](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Users/index.ts#L12)
+
+## Methods
+
+### create()
+
+> **create**(`email`): `Promise`\<[`InviteUsersResponse`](../../types/interfaces/InviteUsersResponse.md)\>
+
+Invite users to your team
+
+#### Parameters
+
+##### email
+
+`string` | `string`[]
+
+#### Returns
+
+`Promise`\<[`InviteUsersResponse`](../../types/interfaces/InviteUsersResponse.md)\>
+
+#### Example
+
+```ts
+const response = await refuel.users.create(["user1@example.com", "user2@example.com"]);
+```
+
+#### Defined in
+
+[src/Users/index.ts:24](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Users/index.ts#L24)
+
+***
+
+### get()
+
+> **get**(`userId`): `Promise`\<[`User`](../../types/interfaces/User.md)\>
+
+Get a user by ID
+
+#### Parameters
+
+##### userId
+
+`string`
+
+#### Returns
+
+`Promise`\<[`User`](../../types/interfaces/User.md)\>
+
+#### Example
+
+```ts
+const user = await refuel.users.get(userId);
+```
+
+#### Defined in
+
+[src/Users/index.ts:40](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Users/index.ts#L40)
+
+***
+
+### list()
+
+> **list**(): `Promise`\<[`User`](../../types/interfaces/User.md)[]\>
+
+List all users in your team
+
+#### Returns
+
+`Promise`\<[`User`](../../types/interfaces/User.md)[]\>
+
+#### Example
+
+```ts
+const users = await refuel.users.list();
+```
+
+#### Defined in
+
+[src/Users/index.ts:52](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/Users/index.ts#L52)

--- a/docs/consts/README.md
+++ b/docs/consts/README.md
@@ -1,0 +1,16 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / consts
+
+# consts
+
+## Index
+
+### Variables
+
+- [DEFAULT\_BASE\_URL](variables/DEFAULT_BASE_URL.md)
+- [DEFAULT\_INITIAL\_RETRY\_TIMEOUT](variables/DEFAULT_INITIAL_RETRY_TIMEOUT.md)
+- [DEFAULT\_MAX\_RETRIES](variables/DEFAULT_MAX_RETRIES.md)
+- [DEFAULT\_RETRY\_STATUS\_CODES](variables/DEFAULT_RETRY_STATUS_CODES.md)

--- a/docs/consts/variables/DEFAULT_BASE_URL.md
+++ b/docs/consts/variables/DEFAULT_BASE_URL.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [consts](../README.md) / DEFAULT\_BASE\_URL
+
+# Variable: DEFAULT\_BASE\_URL
+
+> `const` **DEFAULT\_BASE\_URL**: `"https://cloud-api.refuel.ai"` = `"https://cloud-api.refuel.ai"`
+
+## Defined in
+
+[src/consts.ts:1](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/consts.ts#L1)

--- a/docs/consts/variables/DEFAULT_INITIAL_RETRY_TIMEOUT.md
+++ b/docs/consts/variables/DEFAULT_INITIAL_RETRY_TIMEOUT.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [consts](../README.md) / DEFAULT\_INITIAL\_RETRY\_TIMEOUT
+
+# Variable: DEFAULT\_INITIAL\_RETRY\_TIMEOUT
+
+> `const` **DEFAULT\_INITIAL\_RETRY\_TIMEOUT**: `2500` = `2_500`
+
+## Defined in
+
+[src/consts.ts:3](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/consts.ts#L3)

--- a/docs/consts/variables/DEFAULT_MAX_RETRIES.md
+++ b/docs/consts/variables/DEFAULT_MAX_RETRIES.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [consts](../README.md) / DEFAULT\_MAX\_RETRIES
+
+# Variable: DEFAULT\_MAX\_RETRIES
+
+> `const` **DEFAULT\_MAX\_RETRIES**: `5` = `5`
+
+## Defined in
+
+[src/consts.ts:2](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/consts.ts#L2)

--- a/docs/consts/variables/DEFAULT_RETRY_STATUS_CODES.md
+++ b/docs/consts/variables/DEFAULT_RETRY_STATUS_CODES.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [consts](../README.md) / DEFAULT\_RETRY\_STATUS\_CODES
+
+# Variable: DEFAULT\_RETRY\_STATUS\_CODES
+
+> `const` **DEFAULT\_RETRY\_STATUS\_CODES**: `number`[]
+
+## Defined in
+
+[src/consts.ts:4](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/consts.ts#L4)

--- a/docs/index/README.md
+++ b/docs/index/README.md
@@ -1,0 +1,451 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / index
+
+# index
+
+## Index
+
+### Classes
+
+- [Refuel](classes/Refuel.md)
+
+## References
+
+### Application
+
+Re-exports [Application](../types/interfaces/Application.md)
+
+***
+
+### ApplicationCreateOptions
+
+Re-exports [ApplicationCreateOptions](../types/interfaces/ApplicationCreateOptions.md)
+
+***
+
+### ApplicationLabel
+
+Re-exports [ApplicationLabel](../types/interfaces/ApplicationLabel.md)
+
+***
+
+### ApplicationLabelOptions
+
+Re-exports [ApplicationLabelOptions](../types/interfaces/ApplicationLabelOptions.md)
+
+***
+
+### ApplicationLabelResponse
+
+Re-exports [ApplicationLabelResponse](../types/interfaces/ApplicationLabelResponse.md)
+
+***
+
+### ApplicationOutputAsync
+
+Re-exports [ApplicationOutputAsync](../types/interfaces/ApplicationOutputAsync.md)
+
+***
+
+### ApplicationOutputSync
+
+Re-exports [ApplicationOutputSync](../types/interfaces/ApplicationOutputSync.md)
+
+***
+
+### AuthenticatedUser
+
+Re-exports [AuthenticatedUser](../types/interfaces/AuthenticatedUser.md)
+
+***
+
+### AvailabilityStatus
+
+Re-exports [AvailabilityStatus](../types/enumerations/AvailabilityStatus.md)
+
+***
+
+### ColumnMetadata
+
+Re-exports [ColumnMetadata](../types/interfaces/ColumnMetadata.md)
+
+***
+
+### Dataset
+
+Re-exports [Dataset](../types/interfaces/Dataset.md)
+
+***
+
+### DatasetColumnType
+
+Re-exports [DatasetColumnType](../types/enumerations/DatasetColumnType.md)
+
+***
+
+### DatasetFromList
+
+Re-exports [DatasetFromList](../types/interfaces/DatasetFromList.md)
+
+***
+
+### DatasetItemLabel
+
+Re-exports [DatasetItemLabel](../types/interfaces/DatasetItemLabel.md)
+
+***
+
+### DatasetItemLabels
+
+Re-exports [DatasetItemLabels](../types/interfaces/DatasetItemLabels.md)
+
+***
+
+### DatasetItemLabelsUpdate
+
+Re-exports [DatasetItemLabelsUpdate](../types/interfaces/DatasetItemLabelsUpdate.md)
+
+***
+
+### DatasetItemLabelUpdateData
+
+Re-exports [DatasetItemLabelUpdateData](../types/type-aliases/DatasetItemLabelUpdateData.md)
+
+***
+
+### DatasetItemsOptions
+
+Re-exports [DatasetItemsOptions](../types/interfaces/DatasetItemsOptions.md)
+
+***
+
+### DatasetSchema
+
+Re-exports [DatasetSchema](../types/interfaces/DatasetSchema.md)
+
+***
+
+### DatasetSchemaColumn
+
+Re-exports [DatasetSchemaColumn](../types/interfaces/DatasetSchemaColumn.md)
+
+***
+
+### DeepPartial
+
+Re-exports [DeepPartial](../types/type-aliases/DeepPartial.md)
+
+***
+
+### EvaluationStat
+
+Re-exports [EvaluationStat](../types/interfaces/EvaluationStat.md)
+
+***
+
+### ExportDatasetOptions
+
+Re-exports [ExportDatasetOptions](../types/interfaces/ExportDatasetOptions.md)
+
+***
+
+### ExportDatasetResponse
+
+Re-exports [ExportDatasetResponse](../types/interfaces/ExportDatasetResponse.md)
+
+***
+
+### FeatureFlagValues
+
+Re-exports [FeatureFlagValues](../types/enumerations/FeatureFlagValues.md)
+
+***
+
+### FilterFieldCategory
+
+Re-exports [FilterFieldCategory](../types/enumerations/FilterFieldCategory.md)
+
+***
+
+### FilterOperator
+
+Re-exports [FilterOperator](../types/enumerations/FilterOperator.md)
+
+***
+
+### FilterOperatorOption
+
+Re-exports [FilterOperatorOption](../types/type-aliases/FilterOperatorOption.md)
+
+***
+
+### FilterValueType
+
+Re-exports [FilterValueType](../types/type-aliases/FilterValueType.md)
+
+***
+
+### FinetunedModelCreateOptions
+
+Re-exports [FinetunedModelCreateOptions](../types/type-aliases/FinetunedModelCreateOptions.md)
+
+***
+
+### FinetuningHyperparameters
+
+Re-exports [FinetuningHyperparameters](../types/interfaces/FinetuningHyperparameters.md)
+
+***
+
+### FinetuningRunStage
+
+Re-exports [FinetuningRunStage](../types/interfaces/FinetuningRunStage.md)
+
+***
+
+### FinetuningRunStatus
+
+Re-exports [FinetuningRunStatus](../types/enumerations/FinetuningRunStatus.md)
+
+***
+
+### Integration
+
+Re-exports [Integration](../types/interfaces/Integration.md)
+
+***
+
+### IntegrationConfig
+
+Re-exports [IntegrationConfig](../types/type-aliases/IntegrationConfig.md)
+
+***
+
+### InviteUsersResponse
+
+Re-exports [InviteUsersResponse](../types/interfaces/InviteUsersResponse.md)
+
+***
+
+### LabeledDatasetItem
+
+Re-exports [LabeledDatasetItem](../types/interfaces/LabeledDatasetItem.md)
+
+***
+
+### LabelingModel
+
+Re-exports [LabelingModel](../types/interfaces/LabelingModel.md)
+
+***
+
+### LabelListOptions
+
+Re-exports [LabelListOptions](../types/interfaces/LabelListOptions.md)
+
+***
+
+### LabelSource
+
+Re-exports [LabelSource](../types/enumerations/LabelSource.md)
+
+***
+
+### Metadata
+
+Re-exports [Metadata](../types/interfaces/Metadata.md)
+
+***
+
+### MetricFormat
+
+Re-exports [MetricFormat](../types/enumerations/MetricFormat.md)
+
+***
+
+### MetricResult
+
+Re-exports [MetricResult](../types/interfaces/MetricResult.md)
+
+***
+
+### Project
+
+Re-exports [Project](../types/interfaces/Project.md)
+
+***
+
+### ProjectData
+
+Re-exports [ProjectData](../types/interfaces/ProjectData.md)
+
+***
+
+### RefuelOptions
+
+Re-exports [RefuelOptions](../types/type-aliases/RefuelOptions.md)
+
+***
+
+### RefuelTeam
+
+Re-exports [RefuelTeam](../types/interfaces/RefuelTeam.md)
+
+***
+
+### RequestOptions
+
+Re-exports [RequestOptions](../types/interfaces/RequestOptions.md)
+
+***
+
+### SchemaMode
+
+Re-exports [SchemaMode](../types/enumerations/SchemaMode.md)
+
+***
+
+### SortDirection
+
+Re-exports [SortDirection](../types/type-aliases/SortDirection.md)
+
+***
+
+### SQLFilter
+
+Re-exports [SQLFilter](../types/interfaces/SQLFilter.md)
+
+***
+
+### Subtask
+
+Re-exports [Subtask](../types/interfaces/Subtask.md)
+
+***
+
+### Task
+
+Re-exports [Task](../types/interfaces/Task.md)
+
+***
+
+### TaskRun
+
+Re-exports [TaskRun](../types/interfaces/TaskRun.md)
+
+***
+
+### TaskRunCancelOptions
+
+Re-exports [TaskRunCancelOptions](../types/interfaces/TaskRunCancelOptions.md)
+
+***
+
+### TaskRunCreateOptions
+
+Re-exports [TaskRunCreateOptions](../types/interfaces/TaskRunCreateOptions.md)
+
+***
+
+### TaskRunListOptions
+
+Re-exports [TaskRunListOptions](../types/interfaces/TaskRunListOptions.md)
+
+***
+
+### TaskRunMetrics
+
+Re-exports [TaskRunMetrics](../types/interfaces/TaskRunMetrics.md)
+
+***
+
+### TaskRunStatus
+
+Re-exports [TaskRunStatus](../types/type-aliases/TaskRunStatus.md)
+
+***
+
+### TaskType
+
+Re-exports [TaskType](../types/enumerations/TaskType.md)
+
+***
+
+### TaxonomyLabel
+
+Re-exports [TaxonomyLabel](../types/interfaces/TaxonomyLabel.md)
+
+***
+
+### TaxonomyLabelData
+
+Re-exports [TaxonomyLabelData](../types/interfaces/TaxonomyLabelData.md)
+
+***
+
+### TaxonomyLabelRequestBody
+
+Re-exports [TaxonomyLabelRequestBody](../types/interfaces/TaxonomyLabelRequestBody.md)
+
+***
+
+### TaxonomyLabelsResponse
+
+Re-exports [TaxonomyLabelsResponse](../types/interfaces/TaxonomyLabelsResponse.md)
+
+***
+
+### TeamModel
+
+Re-exports [TeamModel](../types/interfaces/TeamModel.md)
+
+***
+
+### Telemetry
+
+Re-exports [Telemetry](../types/interfaces/Telemetry.md)
+
+***
+
+### Transform
+
+Re-exports [Transform](../types/interfaces/Transform.md)
+
+***
+
+### TransformType
+
+Re-exports [TransformType](../types/enumerations/TransformType.md)
+
+***
+
+### UsageData
+
+Re-exports [UsageData](../types/type-aliases/UsageData.md)
+
+***
+
+### UsageMetric
+
+Re-exports [UsageMetric](../types/interfaces/UsageMetric.md)
+
+***
+
+### UsageMetricKey
+
+Re-exports [UsageMetricKey](../types/type-aliases/UsageMetricKey.md)
+
+***
+
+### User
+
+Re-exports [User](../types/interfaces/User.md)
+
+***
+
+### UserState
+
+Re-exports [UserState](../types/enumerations/UserState.md)

--- a/docs/index/classes/Refuel.md
+++ b/docs/index/classes/Refuel.md
@@ -1,0 +1,220 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [index](../README.md) / Refuel
+
+# Class: Refuel
+
+Main class for interacting with the Refuel API.
+
+## Example
+
+```ts
+// Initialize the Refuel class with your access token
+const refuel = new Refuel(accessToken);
+
+// List all projects
+const projects = await refuel.projects.list();
+console.log(projects);
+```
+
+## Constructors
+
+### new Refuel()
+
+> **new Refuel**(`options`?): [`Refuel`](Refuel.md)
+
+#### Parameters
+
+##### options?
+
+`string` | [`RefuelOptions`](../../types/type-aliases/RefuelOptions.md)
+
+#### Returns
+
+[`Refuel`](Refuel.md)
+
+#### Defined in
+
+[src/index.ts:55](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L55)
+
+## Properties
+
+### applications
+
+> `readonly` **applications**: [`Applications`](../../Applications/classes/Applications.md)
+
+#### Defined in
+
+[src/index.ts:37](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L37)
+
+***
+
+### base
+
+> `readonly` **base**: `RefuelBase`
+
+#### Defined in
+
+[src/index.ts:35](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L35)
+
+***
+
+### datasetExports
+
+> `readonly` **datasetExports**: [`DatasetExports`](../../DatasetExports/classes/DatasetExports.md)
+
+#### Defined in
+
+[src/index.ts:38](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L38)
+
+***
+
+### datasetItems
+
+> `readonly` **datasetItems**: [`DatasetItems`](../../DatasetItems/classes/DatasetItems.md)
+
+#### Defined in
+
+[src/index.ts:39](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L39)
+
+***
+
+### datasets
+
+> `readonly` **datasets**: [`Datasets`](../../Datasets/classes/Datasets.md)
+
+#### Defined in
+
+[src/index.ts:40](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L40)
+
+***
+
+### finetunedModels
+
+> `readonly` **finetunedModels**: [`FinetunedModels`](../../FinetunedModels/classes/FinetunedModels.md)
+
+#### Defined in
+
+[src/index.ts:41](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L41)
+
+***
+
+### integrations
+
+> `readonly` **integrations**: [`Integrations`](../../Integrations/classes/Integrations.md)
+
+#### Defined in
+
+[src/index.ts:42](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L42)
+
+***
+
+### labels
+
+> `readonly` **labels**: [`Labels`](../../Labels/classes/Labels.md)
+
+#### Defined in
+
+[src/index.ts:43](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L43)
+
+***
+
+### projects
+
+> `readonly` **projects**: [`Projects`](../../Projects/classes/Projects.md)
+
+#### Defined in
+
+[src/index.ts:44](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L44)
+
+***
+
+### taskModels
+
+> `readonly` **taskModels**: [`TaskModels`](../../TaskModels/classes/TaskModels.md)
+
+#### Defined in
+
+[src/index.ts:45](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L45)
+
+***
+
+### taskRuns
+
+> `readonly` **taskRuns**: [`TaskRuns`](../../TaskRuns/classes/TaskRuns.md)
+
+#### Defined in
+
+[src/index.ts:46](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L46)
+
+***
+
+### tasks
+
+> `readonly` **tasks**: [`Tasks`](../../Tasks/classes/Tasks.md)
+
+#### Defined in
+
+[src/index.ts:47](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L47)
+
+***
+
+### taxonomies
+
+> `readonly` **taxonomies**: [`Taxonomies`](../../Taxonomies/classes/Taxonomies.md)
+
+#### Defined in
+
+[src/index.ts:48](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L48)
+
+***
+
+### taxonomyLabels
+
+> `readonly` **taxonomyLabels**: [`TaxonomyLabels`](../../TaxonomyLabels/classes/TaxonomyLabels.md)
+
+#### Defined in
+
+[src/index.ts:49](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L49)
+
+***
+
+### team
+
+> `readonly` **team**: [`Team`](../../Team/classes/Team.md)
+
+#### Defined in
+
+[src/index.ts:50](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L50)
+
+***
+
+### teamModels
+
+> `readonly` **teamModels**: [`TeamModels`](../../TeamModels/classes/TeamModels.md)
+
+#### Defined in
+
+[src/index.ts:51](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L51)
+
+***
+
+### usage
+
+> `readonly` **usage**: [`Usage`](../../Usage/classes/Usage.md)
+
+#### Defined in
+
+[src/index.ts:52](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L52)
+
+***
+
+### users
+
+> `readonly` **users**: [`Users`](../../Users/classes/Users.md)
+
+#### Defined in
+
+[src/index.ts:53](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/index.ts#L53)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,29 @@
+[**refuel-sdk**](README.md)
+
+***
+
+# refuel-sdk
+
+## Modules
+
+- [Applications](Applications/README.md)
+- [consts](consts/README.md)
+- [DatasetExports](DatasetExports/README.md)
+- [DatasetItems](DatasetItems/README.md)
+- [Datasets](Datasets/README.md)
+- [FinetunedModels](FinetunedModels/README.md)
+- [index](index/README.md)
+- [Integrations](Integrations/README.md)
+- [Labels](Labels/README.md)
+- [Projects](Projects/README.md)
+- [RefuelBase](RefuelBase/README.md)
+- [TaskModels](TaskModels/README.md)
+- [TaskRuns](TaskRuns/README.md)
+- [Tasks](Tasks/README.md)
+- [Taxonomies](Taxonomies/README.md)
+- [TaxonomyLabels](TaxonomyLabels/README.md)
+- [Team](Team/README.md)
+- [TeamModels](TeamModels/README.md)
+- [types](types/README.md)
+- [Usage](Usage/README.md)
+- [Users](Users/README.md)

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -1,0 +1,91 @@
+[**refuel-sdk**](../README.md)
+
+***
+
+[refuel-sdk](../modules.md) / types
+
+# types
+
+## Index
+
+### Enumerations
+
+- [AvailabilityStatus](enumerations/AvailabilityStatus.md)
+- [DatasetColumnType](enumerations/DatasetColumnType.md)
+- [FeatureFlagValues](enumerations/FeatureFlagValues.md)
+- [FilterFieldCategory](enumerations/FilterFieldCategory.md)
+- [FilterOperator](enumerations/FilterOperator.md)
+- [FinetuningRunStatus](enumerations/FinetuningRunStatus.md)
+- [LabelSource](enumerations/LabelSource.md)
+- [MetricFormat](enumerations/MetricFormat.md)
+- [SchemaMode](enumerations/SchemaMode.md)
+- [TaskType](enumerations/TaskType.md)
+- [TransformType](enumerations/TransformType.md)
+- [UserState](enumerations/UserState.md)
+
+### Interfaces
+
+- [Application](interfaces/Application.md)
+- [ApplicationCreateOptions](interfaces/ApplicationCreateOptions.md)
+- [ApplicationLabel](interfaces/ApplicationLabel.md)
+- [ApplicationLabelOptions](interfaces/ApplicationLabelOptions.md)
+- [ApplicationLabelResponse](interfaces/ApplicationLabelResponse.md)
+- [ApplicationOutputAsync](interfaces/ApplicationOutputAsync.md)
+- [ApplicationOutputSync](interfaces/ApplicationOutputSync.md)
+- [AuthenticatedUser](interfaces/AuthenticatedUser.md)
+- [ColumnMetadata](interfaces/ColumnMetadata.md)
+- [Dataset](interfaces/Dataset.md)
+- [DatasetFromList](interfaces/DatasetFromList.md)
+- [DatasetItemLabel](interfaces/DatasetItemLabel.md)
+- [DatasetItemLabels](interfaces/DatasetItemLabels.md)
+- [DatasetItemLabelsUpdate](interfaces/DatasetItemLabelsUpdate.md)
+- [DatasetItemsOptions](interfaces/DatasetItemsOptions.md)
+- [DatasetSchema](interfaces/DatasetSchema.md)
+- [DatasetSchemaColumn](interfaces/DatasetSchemaColumn.md)
+- [EvaluationStat](interfaces/EvaluationStat.md)
+- [ExportDatasetOptions](interfaces/ExportDatasetOptions.md)
+- [ExportDatasetResponse](interfaces/ExportDatasetResponse.md)
+- [FinetuningHyperparameters](interfaces/FinetuningHyperparameters.md)
+- [FinetuningRunStage](interfaces/FinetuningRunStage.md)
+- [Integration](interfaces/Integration.md)
+- [InviteUsersResponse](interfaces/InviteUsersResponse.md)
+- [LabeledDatasetItem](interfaces/LabeledDatasetItem.md)
+- [LabelingModel](interfaces/LabelingModel.md)
+- [LabelListOptions](interfaces/LabelListOptions.md)
+- [Metadata](interfaces/Metadata.md)
+- [MetricResult](interfaces/MetricResult.md)
+- [Project](interfaces/Project.md)
+- [ProjectData](interfaces/ProjectData.md)
+- [RefuelTeam](interfaces/RefuelTeam.md)
+- [RequestOptions](interfaces/RequestOptions.md)
+- [SQLFilter](interfaces/SQLFilter.md)
+- [Subtask](interfaces/Subtask.md)
+- [Task](interfaces/Task.md)
+- [TaskRun](interfaces/TaskRun.md)
+- [TaskRunCancelOptions](interfaces/TaskRunCancelOptions.md)
+- [TaskRunCreateOptions](interfaces/TaskRunCreateOptions.md)
+- [TaskRunListOptions](interfaces/TaskRunListOptions.md)
+- [TaskRunMetrics](interfaces/TaskRunMetrics.md)
+- [TaxonomyLabel](interfaces/TaxonomyLabel.md)
+- [TaxonomyLabelData](interfaces/TaxonomyLabelData.md)
+- [TaxonomyLabelRequestBody](interfaces/TaxonomyLabelRequestBody.md)
+- [TaxonomyLabelsResponse](interfaces/TaxonomyLabelsResponse.md)
+- [TeamModel](interfaces/TeamModel.md)
+- [Telemetry](interfaces/Telemetry.md)
+- [Transform](interfaces/Transform.md)
+- [UsageMetric](interfaces/UsageMetric.md)
+- [User](interfaces/User.md)
+
+### Type Aliases
+
+- [DatasetItemLabelUpdateData](type-aliases/DatasetItemLabelUpdateData.md)
+- [DeepPartial](type-aliases/DeepPartial.md)
+- [FilterOperatorOption](type-aliases/FilterOperatorOption.md)
+- [FilterValueType](type-aliases/FilterValueType.md)
+- [FinetunedModelCreateOptions](type-aliases/FinetunedModelCreateOptions.md)
+- [IntegrationConfig](type-aliases/IntegrationConfig.md)
+- [RefuelOptions](type-aliases/RefuelOptions.md)
+- [SortDirection](type-aliases/SortDirection.md)
+- [TaskRunStatus](type-aliases/TaskRunStatus.md)
+- [UsageData](type-aliases/UsageData.md)
+- [UsageMetricKey](type-aliases/UsageMetricKey.md)

--- a/docs/types/enumerations/AvailabilityStatus.md
+++ b/docs/types/enumerations/AvailabilityStatus.md
@@ -1,0 +1,29 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / AvailabilityStatus
+
+# Enumeration: AvailabilityStatus
+
+The availability status of a labeling model
+
+## Enumeration Members
+
+### AVAILABLE
+
+> **AVAILABLE**: `"AVAILABLE"`
+
+#### Defined in
+
+[src/types.ts:1146](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1146)
+
+***
+
+### UNAVAILABLE
+
+> **UNAVAILABLE**: `"UNAVAILABLE"`
+
+#### Defined in
+
+[src/types.ts:1145](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1145)

--- a/docs/types/enumerations/DatasetColumnType.md
+++ b/docs/types/enumerations/DatasetColumnType.md
@@ -1,0 +1,59 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetColumnType
+
+# Enumeration: DatasetColumnType
+
+The type of a column value
+
+## Enumeration Members
+
+### BOOLEAN
+
+> **BOOLEAN**: `"boolean"`
+
+#### Defined in
+
+[src/types.ts:375](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L375)
+
+***
+
+### IMAGE\_URL
+
+> **IMAGE\_URL**: `"image_url"`
+
+#### Defined in
+
+[src/types.ts:376](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L376)
+
+***
+
+### NUMBER
+
+> **NUMBER**: `"number"`
+
+#### Defined in
+
+[src/types.ts:374](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L374)
+
+***
+
+### PDF\_URL
+
+> **PDF\_URL**: `"pdf_url"`
+
+#### Defined in
+
+[src/types.ts:377](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L377)
+
+***
+
+### STRING
+
+> **STRING**: `"string"`
+
+#### Defined in
+
+[src/types.ts:373](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L373)

--- a/docs/types/enumerations/FeatureFlagValues.md
+++ b/docs/types/enumerations/FeatureFlagValues.md
@@ -1,0 +1,27 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FeatureFlagValues
+
+# Enumeration: FeatureFlagValues
+
+## Enumeration Members
+
+### DISABLED
+
+> **DISABLED**: `"disabled"`
+
+#### Defined in
+
+[src/types.ts:799](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L799)
+
+***
+
+### ENABLED
+
+> **ENABLED**: `"enabled"`
+
+#### Defined in
+
+[src/types.ts:798](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L798)

--- a/docs/types/enumerations/FilterFieldCategory.md
+++ b/docs/types/enumerations/FilterFieldCategory.md
@@ -1,0 +1,45 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FilterFieldCategory
+
+# Enumeration: FilterFieldCategory
+
+The category of a filter field
+
+## Enumeration Members
+
+### LABEL
+
+> **LABEL**: `"label"`
+
+Filter on a label
+
+#### Defined in
+
+[src/types.ts:462](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L462)
+
+***
+
+### METADATA
+
+> **METADATA**: `"metadata"`
+
+Filter on metadata
+
+#### Defined in
+
+[src/types.ts:465](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L465)
+
+***
+
+### SIMILAR
+
+> **SIMILAR**: `"similar"`
+
+Filter on similar items
+
+#### Defined in
+
+[src/types.ts:468](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L468)

--- a/docs/types/enumerations/FilterOperator.md
+++ b/docs/types/enumerations/FilterOperator.md
@@ -1,0 +1,201 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FilterOperator
+
+# Enumeration: FilterOperator
+
+The operator to use for a filter
+
+## Enumeration Members
+
+### EQUAL
+
+> **EQUAL**: `"="`
+
+Equal to
+
+#### Defined in
+
+[src/types.ts:476](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L476)
+
+***
+
+### GREATER\_THAN
+
+> **GREATER\_THAN**: `">"`
+
+Greater than
+
+#### Defined in
+
+[src/types.ts:479](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L479)
+
+***
+
+### GREATER\_THAN\_OR\_EQUAL
+
+> **GREATER\_THAN\_OR\_EQUAL**: `">="`
+
+Greater than or equal to
+
+#### Defined in
+
+[src/types.ts:482](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L482)
+
+***
+
+### ILIKE
+
+> **ILIKE**: `"ILIKE"`
+
+ILIKE
+
+#### Defined in
+
+[src/types.ts:485](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L485)
+
+***
+
+### IN
+
+> **IN**: `"IN"`
+
+In a list
+
+#### Defined in
+
+[src/types.ts:488](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L488)
+
+***
+
+### IS\_NOT\_VERIFIED
+
+> **IS\_NOT\_VERIFIED**: `"IS NOT VERIFIED"`
+
+Is not verified
+
+#### Defined in
+
+[src/types.ts:491](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L491)
+
+***
+
+### IS\_VERIFIED
+
+> **IS\_VERIFIED**: `"IS VERIFIED"`
+
+Is verified
+
+#### Defined in
+
+[src/types.ts:494](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L494)
+
+***
+
+### LESS\_THAN
+
+> **LESS\_THAN**: `"<"`
+
+Less than
+
+#### Defined in
+
+[src/types.ts:497](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L497)
+
+***
+
+### LESS\_THAN\_OR\_EQUAL
+
+> **LESS\_THAN\_OR\_EQUAL**: `"<="`
+
+Less than or equal to
+
+#### Defined in
+
+[src/types.ts:500](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L500)
+
+***
+
+### MATCHES
+
+> **MATCHES**: `"~*"`
+
+Matches
+
+#### Defined in
+
+[src/types.ts:503](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L503)
+
+***
+
+### NOT\_EQUAL
+
+> **NOT\_EQUAL**: `"<>"`
+
+Not equal to
+
+#### Defined in
+
+[src/types.ts:506](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L506)
+
+***
+
+### NOT\_ILIKE
+
+> **NOT\_ILIKE**: `"NOT ILIKE"`
+
+Not ILIKE
+
+#### Defined in
+
+[src/types.ts:509](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L509)
+
+***
+
+### NOT\_MATCHES
+
+> **NOT\_MATCHES**: `"!~*"`
+
+Not matches
+
+#### Defined in
+
+[src/types.ts:512](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L512)
+
+***
+
+### NOT\_NULL
+
+> **NOT\_NULL**: `"IS NOT NULL"`
+
+Not null
+
+#### Defined in
+
+[src/types.ts:515](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L515)
+
+***
+
+### NULL
+
+> **NULL**: `"IS NULL"`
+
+Null
+
+#### Defined in
+
+[src/types.ts:518](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L518)
+
+***
+
+### SIMILAR
+
+> **SIMILAR**: `"SIMILAR"`
+
+Similar to another item
+
+#### Defined in
+
+[src/types.ts:521](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L521)

--- a/docs/types/enumerations/FinetuningRunStatus.md
+++ b/docs/types/enumerations/FinetuningRunStatus.md
@@ -1,0 +1,239 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FinetuningRunStatus
+
+# Enumeration: FinetuningRunStatus
+
+The status of a finetuning run
+
+## Enumeration Members
+
+### DATASET\_PREP\_COMPLETED
+
+> **DATASET\_PREP\_COMPLETED**: `"DATASET PREPARATION COMPLETED"`
+
+#### Defined in
+
+[src/types.ts:1158](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1158)
+
+***
+
+### DATASET\_PREP\_FAILED
+
+> **DATASET\_PREP\_FAILED**: `"DATASET PREPARATION FAILED"`
+
+#### Defined in
+
+[src/types.ts:1159](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1159)
+
+***
+
+### DATASET\_PREP\_IN\_PROGRESS
+
+> **DATASET\_PREP\_IN\_PROGRESS**: `"DATASET PREPARATION IN PROGRESS"`
+
+#### Defined in
+
+[src/types.ts:1157](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1157)
+
+***
+
+### DATASET\_PREP\_NOT\_STARTED
+
+> **DATASET\_PREP\_NOT\_STARTED**: `"DATASET PREPARATION NOT STARTED"`
+
+#### Defined in
+
+[src/types.ts:1156](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1156)
+
+***
+
+### DEPLOY\_COMPLETED
+
+> **DEPLOY\_COMPLETED**: `"DEPLOYMENT COMPLETED"`
+
+#### Defined in
+
+[src/types.ts:1173](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1173)
+
+***
+
+### DEPLOY\_FAILED
+
+> **DEPLOY\_FAILED**: `"DEPLOYMENT FAILED"`
+
+#### Defined in
+
+[src/types.ts:1174](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1174)
+
+***
+
+### DEPLOY\_IN\_PROGRESS
+
+> **DEPLOY\_IN\_PROGRESS**: `"DEPLOYMENT IN PROGRESS"`
+
+#### Defined in
+
+[src/types.ts:1172](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1172)
+
+***
+
+### DEPLOY\_NOT\_STARTED
+
+> **DEPLOY\_NOT\_STARTED**: `"DEPLOYMENT NOT STARTED"`
+
+#### Defined in
+
+[src/types.ts:1171](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1171)
+
+***
+
+### EVALUATION\_COMPLETED
+
+> **EVALUATION\_COMPLETED**: `"EVALUATION COMPLETED"`
+
+#### Defined in
+
+[src/types.ts:1178](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1178)
+
+***
+
+### EVALUATION\_FAILED
+
+> **EVALUATION\_FAILED**: `"EVALUATION FAILED"`
+
+#### Defined in
+
+[src/types.ts:1179](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1179)
+
+***
+
+### EVALUATION\_IN\_PROGRESS
+
+> **EVALUATION\_IN\_PROGRESS**: `"EVALUATION IN PROGRESS"`
+
+#### Defined in
+
+[src/types.ts:1177](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1177)
+
+***
+
+### EVALUATION\_NOT\_STARTED
+
+> **EVALUATION\_NOT\_STARTED**: `"EVALUATION NOT STARTED"`
+
+#### Defined in
+
+[src/types.ts:1176](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1176)
+
+***
+
+### INITIALIZATION\_COMPLETE
+
+> **INITIALIZATION\_COMPLETE**: `"INITIALIZATION COMPLETE"`
+
+#### Defined in
+
+[src/types.ts:1154](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1154)
+
+***
+
+### INITIALIZATION\_IN\_PROGRESS
+
+> **INITIALIZATION\_IN\_PROGRESS**: `"INITIALIZATION IN PROGRESS"`
+
+#### Defined in
+
+[src/types.ts:1153](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1153)
+
+***
+
+### INTERRUPTED
+
+> **INTERRUPTED**: `"INTERRUPTED"`
+
+#### Defined in
+
+[src/types.ts:1181](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1181)
+
+***
+
+### RESOURCE\_ALLOCATION\_COMPLETED
+
+> **RESOURCE\_ALLOCATION\_COMPLETED**: `"RESOURCE ALLOCATION COMPLETED"`
+
+#### Defined in
+
+[src/types.ts:1163](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1163)
+
+***
+
+### RESOURCE\_ALLOCATION\_FAILED
+
+> **RESOURCE\_ALLOCATION\_FAILED**: `"RESOURCE ALLOCATION FAILED"`
+
+#### Defined in
+
+[src/types.ts:1164](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1164)
+
+***
+
+### RESOURCE\_ALLOCATION\_IN\_PROGRESS
+
+> **RESOURCE\_ALLOCATION\_IN\_PROGRESS**: `"RESOURCE ALLOCATION IN PROGRESS"`
+
+#### Defined in
+
+[src/types.ts:1162](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1162)
+
+***
+
+### RESOURCE\_ALLOCATION\_NOT\_STARTED
+
+> **RESOURCE\_ALLOCATION\_NOT\_STARTED**: `"RESOURCE ALLOCATION NOT STARTED"`
+
+#### Defined in
+
+[src/types.ts:1161](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1161)
+
+***
+
+### TRAINING\_COMPLETED
+
+> **TRAINING\_COMPLETED**: `"TRAINING COMPLETED"`
+
+#### Defined in
+
+[src/types.ts:1168](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1168)
+
+***
+
+### TRAINING\_FAILED
+
+> **TRAINING\_FAILED**: `"TRAINING FAILED"`
+
+#### Defined in
+
+[src/types.ts:1169](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1169)
+
+***
+
+### TRAINING\_IN\_PROGRESS
+
+> **TRAINING\_IN\_PROGRESS**: `"TRAINING IN PROGRESS"`
+
+#### Defined in
+
+[src/types.ts:1167](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1167)
+
+***
+
+### TRAINING\_NOT\_STARTED
+
+> **TRAINING\_NOT\_STARTED**: `"TRAINING NOT STARTED"`
+
+#### Defined in
+
+[src/types.ts:1166](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1166)

--- a/docs/types/enumerations/LabelSource.md
+++ b/docs/types/enumerations/LabelSource.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / LabelSource
+
+# Enumeration: LabelSource
+
+The source of a label value
+
+## Enumeration Members
+
+### HUMAN
+
+> **HUMAN**: `"HUMAN"`
+
+Label from a human
+
+#### Defined in
+
+[src/types.ts:245](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L245)
+
+***
+
+### LLM
+
+> **LLM**: `"LLM"`
+
+Label from an LLM
+
+#### Defined in
+
+[src/types.ts:242](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L242)

--- a/docs/types/enumerations/MetricFormat.md
+++ b/docs/types/enumerations/MetricFormat.md
@@ -1,0 +1,57 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / MetricFormat
+
+# Enumeration: MetricFormat
+
+The format of a metric
+
+## Enumeration Members
+
+### DICT
+
+> **DICT**: `"dict"`
+
+Dictionary metric
+
+#### Defined in
+
+[src/types.ts:1051](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1051)
+
+***
+
+### HISTOGRAM
+
+> **HISTOGRAM**: `"histogram"`
+
+Histogram metric
+
+#### Defined in
+
+[src/types.ts:1048](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1048)
+
+***
+
+### NUMERIC
+
+> **NUMERIC**: `"numeric"`
+
+Numeric metric
+
+#### Defined in
+
+[src/types.ts:1042](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1042)
+
+***
+
+### PERCENTAGE
+
+> **PERCENTAGE**: `"percentage"`
+
+Percentage metric
+
+#### Defined in
+
+[src/types.ts:1045](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1045)

--- a/docs/types/enumerations/SchemaMode.md
+++ b/docs/types/enumerations/SchemaMode.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / SchemaMode
+
+# Enumeration: SchemaMode
+
+The mode to used to generate the schema for a subtask
+
+## Enumeration Members
+
+### AUTO
+
+> **AUTO**: `"auto"`
+
+Automatically generate the schema from the guidelines
+
+#### Defined in
+
+[src/types.ts:576](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L576)
+
+***
+
+### MANUAL
+
+> **MANUAL**: `"manual"`
+
+Manually specify the schema
+
+#### Defined in
+
+[src/types.ts:579](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L579)

--- a/docs/types/enumerations/TaskType.md
+++ b/docs/types/enumerations/TaskType.md
@@ -1,0 +1,81 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaskType
+
+# Enumeration: TaskType
+
+The type of task
+
+## Enumeration Members
+
+### ANSWER\_EXTRACTION
+
+> **ANSWER\_EXTRACTION**: `"answer_extraction"`
+
+Extract an answer from an item
+
+#### Defined in
+
+[src/types.ts:677](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L677)
+
+***
+
+### ATTRIBUTE\_EXTRACTION
+
+> **ATTRIBUTE\_EXTRACTION**: `"attribute_extraction"`
+
+Extract attributes from an item
+
+#### Defined in
+
+[src/types.ts:683](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L683)
+
+***
+
+### CLASSIFICATION
+
+> **CLASSIFICATION**: `"classification"`
+
+Classify an item into one category
+
+#### Defined in
+
+[src/types.ts:671](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L671)
+
+***
+
+### DOCUMENT\_EXTRACTION
+
+> **DOCUMENT\_EXTRACTION**: `"document_extraction"`
+
+Extract structured data from a document
+
+#### Defined in
+
+[src/types.ts:680](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L680)
+
+***
+
+### MULTILABEL\_CLASSIFICATION
+
+> **MULTILABEL\_CLASSIFICATION**: `"multilabel_classification"`
+
+Classify an item into one or more categories
+
+#### Defined in
+
+[src/types.ts:674](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L674)
+
+***
+
+### TASK\_CHAIN
+
+> **TASK\_CHAIN**: `"task_chain"`
+
+Chain of tasks
+
+#### Defined in
+
+[src/types.ts:686](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L686)

--- a/docs/types/enumerations/TransformType.md
+++ b/docs/types/enumerations/TransformType.md
@@ -1,0 +1,69 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TransformType
+
+# Enumeration: TransformType
+
+The type of enrichment
+
+## Enumeration Members
+
+### CUSTOM\_API
+
+> **CUSTOM\_API**: `"custom_api"`
+
+Use a custom API to transform the data
+
+#### Defined in
+
+[src/types.ts:645](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L645)
+
+***
+
+### MAP\_SEARCH
+
+> **MAP\_SEARCH**: `"map_search"`
+
+Search for a location on a map
+
+#### Defined in
+
+[src/types.ts:636](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L636)
+
+***
+
+### OCR
+
+> **OCR**: `"ocr"`
+
+Extract text from an image or document
+
+#### Defined in
+
+[src/types.ts:642](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L642)
+
+***
+
+### WEB\_SEARCH
+
+> **WEB\_SEARCH**: `"web_search"`
+
+Search the web for information relevant to the input
+
+#### Defined in
+
+[src/types.ts:633](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L633)
+
+***
+
+### WEBPAGE\_TRANSFORM
+
+> **WEBPAGE\_TRANSFORM**: `"webpage_transform"`
+
+Transform a webpage into structured data
+
+#### Defined in
+
+[src/types.ts:639](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L639)

--- a/docs/types/enumerations/UserState.md
+++ b/docs/types/enumerations/UserState.md
@@ -1,0 +1,45 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / UserState
+
+# Enumeration: UserState
+
+Possible states for a user
+
+## Enumeration Members
+
+### ACTIVE
+
+> **ACTIVE**: `"ACTIVE"`
+
+User is active
+
+#### Defined in
+
+[src/types.ts:827](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L827)
+
+***
+
+### CREATED
+
+> **CREATED**: `"CREATED"`
+
+User has been created but not invited
+
+#### Defined in
+
+[src/types.ts:833](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L833)
+
+***
+
+### INVITED
+
+> **INVITED**: `"INVITED"`
+
+User has been invited to the team
+
+#### Defined in
+
+[src/types.ts:830](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L830)

--- a/docs/types/interfaces/Application.md
+++ b/docs/types/interfaces/Application.md
@@ -1,0 +1,177 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Application
+
+# Interface: Application
+
+Application for labeling items
+
+## Properties
+
+### created\_at
+
+> **created\_at**: `string`
+
+Date the application was created
+
+#### Defined in
+
+[src/types.ts:58](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L58)
+
+***
+
+### dataset\_id
+
+> **dataset\_id**: `string`
+
+Dataset ID the application is associated with
+
+#### Defined in
+
+[src/types.ts:61](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L61)
+
+***
+
+### description?
+
+> `optional` **description**: `string`
+
+Application description
+
+#### Defined in
+
+[src/types.ts:64](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L64)
+
+***
+
+### emoji
+
+> **emoji**: `null` \| `string`
+
+Emoji for the application that can be used as the icon in the UI
+
+#### Defined in
+
+[src/types.ts:67](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L67)
+
+***
+
+### id
+
+> **id**: `string`
+
+Application ID
+
+#### Defined in
+
+[src/types.ts:55](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L55)
+
+***
+
+### input\_columns
+
+> **input\_columns**: `string`[]
+
+Input columns for the application
+
+#### Defined in
+
+[src/types.ts:70](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L70)
+
+***
+
+### model\_name
+
+> **model\_name**: `string`
+
+Model name for the application
+
+#### Defined in
+
+[src/types.ts:73](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L73)
+
+***
+
+### name
+
+> **name**: `string`
+
+Application name
+
+#### Defined in
+
+[src/types.ts:76](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L76)
+
+***
+
+### project\_id
+
+> **project\_id**: `string`
+
+Project ID the application is associated with
+
+#### Defined in
+
+[src/types.ts:79](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L79)
+
+***
+
+### subtasks
+
+> **subtasks**: [`Subtask`](Subtask.md)[]
+
+Subtasks for the application
+
+#### Defined in
+
+[src/types.ts:82](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L82)
+
+***
+
+### task\_id
+
+> **task\_id**: `string`
+
+Task ID the application is associated with
+
+#### Defined in
+
+[src/types.ts:85](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L85)
+
+***
+
+### task\_name
+
+> **task\_name**: `string`
+
+Name of the task the application is associated with
+
+#### Defined in
+
+[src/types.ts:88](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L88)
+
+***
+
+### task\_updated\_at
+
+> **task\_updated\_at**: `null` \| `string`
+
+Date the related task was last updated
+
+#### Defined in
+
+[src/types.ts:91](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L91)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `string`
+
+Date the application was last updated
+
+#### Defined in
+
+[src/types.ts:94](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L94)

--- a/docs/types/interfaces/ApplicationCreateOptions.md
+++ b/docs/types/interfaces/ApplicationCreateOptions.md
@@ -1,0 +1,45 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ApplicationCreateOptions
+
+# Interface: ApplicationCreateOptions
+
+Options to create an application
+
+## Properties
+
+### name?
+
+> `optional` **name**: `string`
+
+Application name
+
+#### Defined in
+
+[src/types.ts:108](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L108)
+
+***
+
+### projectId
+
+> **projectId**: `string`
+
+Project ID to deploy the application to
+
+#### Defined in
+
+[src/types.ts:102](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L102)
+
+***
+
+### taskId
+
+> **taskId**: `string`
+
+Task ID to deploy as an application
+
+#### Defined in
+
+[src/types.ts:105](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L105)

--- a/docs/types/interfaces/ApplicationLabel.md
+++ b/docs/types/interfaces/ApplicationLabel.md
@@ -1,0 +1,57 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ApplicationLabel
+
+# Interface: ApplicationLabel
+
+Label for an item labeled by an application
+
+## Properties
+
+### confidence
+
+> **confidence**: `number`
+
+Confidence score
+
+#### Defined in
+
+[src/types.ts:119](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L119)
+
+***
+
+### explanation?
+
+> `optional` **explanation**: `string`
+
+Explanation of the labeling decision
+
+#### Defined in
+
+[src/types.ts:125](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L125)
+
+***
+
+### label
+
+> **label**: `string`[]
+
+Label value
+
+#### Defined in
+
+[src/types.ts:116](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L116)
+
+***
+
+### raw\_confidence
+
+> **raw\_confidence**: `number`
+
+Uncalibrated confidence score
+
+#### Defined in
+
+[src/types.ts:122](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L122)

--- a/docs/types/interfaces/ApplicationLabelOptions.md
+++ b/docs/types/interfaces/ApplicationLabelOptions.md
@@ -1,0 +1,57 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ApplicationLabelOptions
+
+# Interface: ApplicationLabelOptions
+
+Options for an application request
+
+## Properties
+
+### async?
+
+> `optional` **async**: `boolean`
+
+Process labels asynchronously
+
+#### Defined in
+
+[src/types.ts:183](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L183)
+
+***
+
+### explain?
+
+> `optional` **explain**: `boolean`
+
+Include an explanation of the labeling decision in the response
+
+#### Defined in
+
+[src/types.ts:180](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L180)
+
+***
+
+### modelId?
+
+> `optional` **modelId**: `string`
+
+Model to use
+
+#### Defined in
+
+[src/types.ts:186](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L186)
+
+***
+
+### redactPII?
+
+> `optional` **redactPII**: `boolean`
+
+Redact personally identifiable information
+
+#### Defined in
+
+[src/types.ts:189](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L189)

--- a/docs/types/interfaces/ApplicationLabelResponse.md
+++ b/docs/types/interfaces/ApplicationLabelResponse.md
@@ -1,0 +1,49 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ApplicationLabelResponse
+
+# Interface: ApplicationLabelResponse\<T\>
+
+Response from an application request
+
+## Type Parameters
+
+• **T** = [`ApplicationOutputSync`](ApplicationOutputSync.md) \| [`ApplicationOutputAsync`](ApplicationOutputAsync.md)
+
+## Properties
+
+### application\_id
+
+> **application\_id**: `string`
+
+Application ID
+
+#### Defined in
+
+[src/types.ts:166](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L166)
+
+***
+
+### application\_name
+
+> **application\_name**: `string`
+
+Application name
+
+#### Defined in
+
+[src/types.ts:169](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L169)
+
+***
+
+### refuel\_output
+
+> **refuel\_output**: `T`[]
+
+Output of the application
+
+#### Defined in
+
+[src/types.ts:172](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L172)

--- a/docs/types/interfaces/ApplicationOutputAsync.md
+++ b/docs/types/interfaces/ApplicationOutputAsync.md
@@ -1,0 +1,45 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ApplicationOutputAsync
+
+# Interface: ApplicationOutputAsync
+
+Output of an asynchronous application request
+
+## Properties
+
+### refuel\_api\_timestamp
+
+> **refuel\_api\_timestamp**: `string`
+
+Timestamp of the output
+
+#### Defined in
+
+[src/types.ts:153](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L153)
+
+***
+
+### refuel\_uuid
+
+> **refuel\_uuid**: `string`
+
+Refuel UUID for the output
+
+#### Defined in
+
+[src/types.ts:150](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L150)
+
+***
+
+### uri
+
+> **uri**: `string`
+
+URI to the output value
+
+#### Defined in
+
+[src/types.ts:156](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L156)

--- a/docs/types/interfaces/ApplicationOutputSync.md
+++ b/docs/types/interfaces/ApplicationOutputSync.md
@@ -1,0 +1,61 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ApplicationOutputSync
+
+# Interface: ApplicationOutputSync\<FieldKeys\>
+
+Output of a synchronous application request
+
+## Type Parameters
+
+• **FieldKeys** *extends* `string` = `string`
+
+## Properties
+
+### refuel\_api\_timestamp
+
+> **refuel\_api\_timestamp**: `string`
+
+Timestamp of the output
+
+#### Defined in
+
+[src/types.ts:136](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L136)
+
+***
+
+### refuel\_fields
+
+> **refuel\_fields**: `Record`\<`FieldKeys`, [`ApplicationLabel`](ApplicationLabel.md)\>
+
+Fields and their labels
+
+#### Defined in
+
+[src/types.ts:139](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L139)
+
+***
+
+### refuel\_uuid
+
+> **refuel\_uuid**: `string`
+
+Refuel UUID for the output
+
+#### Defined in
+
+[src/types.ts:133](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L133)
+
+***
+
+### usage?
+
+> `optional` **usage**: `Record`\<`string`, `unknown`\>
+
+Telemetry metrics, such as how many tokens were used
+
+#### Defined in
+
+[src/types.ts:142](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L142)

--- a/docs/types/interfaces/AuthenticatedUser.md
+++ b/docs/types/interfaces/AuthenticatedUser.md
@@ -1,0 +1,165 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / AuthenticatedUser
+
+# Interface: AuthenticatedUser
+
+Logged in user
+
+## Extends
+
+- [`User`](User.md)
+
+## Properties
+
+### access\_token
+
+> **access\_token**: `string`
+
+Access token used to authenticate requests
+
+#### Defined in
+
+[src/types.ts:876](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L876)
+
+***
+
+### api\_key
+
+> **api\_key**: `null` \| `string`
+
+API key
+
+#### Defined in
+
+[src/types.ts:864](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L864)
+
+***
+
+### created\_at
+
+> **created\_at**: `string`
+
+Date the user was created
+
+#### Defined in
+
+[src/types.ts:867](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L867)
+
+***
+
+### email
+
+> **email**: `string`
+
+User email
+
+#### Inherited from
+
+[`User`](User.md).[`email`](User.md#email)
+
+#### Defined in
+
+[src/types.ts:844](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L844)
+
+***
+
+### id
+
+> **id**: `string`
+
+User ID
+
+#### Defined in
+
+[src/types.ts:861](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L861)
+
+***
+
+### name
+
+> **name**: `null` \| `string`
+
+User name
+
+#### Inherited from
+
+[`User`](User.md).[`name`](User.md#name)
+
+#### Defined in
+
+[src/types.ts:841](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L841)
+
+***
+
+### permissions
+
+> **permissions**: `string`[]
+
+Permissions the user has
+
+#### Defined in
+
+[src/types.ts:870](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L870)
+
+***
+
+### picture
+
+> **picture**: `null` \| `string`
+
+URL to the user's picture
+
+#### Inherited from
+
+[`User`](User.md).[`picture`](User.md#picture)
+
+#### Defined in
+
+[src/types.ts:850](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L850)
+
+***
+
+### state
+
+> **state**: [`UserState`](../enumerations/UserState.md)
+
+User state
+
+#### Inherited from
+
+[`User`](User.md).[`state`](User.md#state)
+
+#### Defined in
+
+[src/types.ts:853](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L853)
+
+***
+
+### team
+
+> **team**: `string`
+
+Team the user is associated with
+
+#### Inherited from
+
+[`User`](User.md).[`team`](User.md#team)
+
+#### Defined in
+
+[src/types.ts:847](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L847)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `string`
+
+Date the user was last updated
+
+#### Defined in
+
+[src/types.ts:873](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L873)

--- a/docs/types/interfaces/ColumnMetadata.md
+++ b/docs/types/interfaces/ColumnMetadata.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ColumnMetadata
+
+# Interface: ColumnMetadata
+
+Metadata for columns in a dataset
+
+## Indexable
+
+ \[`key`: `string`\]: [`Metadata`](Metadata.md)

--- a/docs/types/interfaces/Dataset.md
+++ b/docs/types/interfaces/Dataset.md
@@ -1,0 +1,103 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Dataset
+
+# Interface: Dataset
+
+## Properties
+
+### column\_metadata
+
+> **column\_metadata**: `null` \| [`ColumnMetadata`](ColumnMetadata.md)
+
+Metadata for the columns
+
+#### Defined in
+
+[src/types.ts:436](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L436)
+
+***
+
+### id
+
+> **id**: `string`
+
+Dataset ID
+
+#### Defined in
+
+[src/types.ts:433](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L433)
+
+***
+
+### ingest\_status
+
+> **ingest\_status**: `null` \| `string`
+
+Ingest status
+
+#### Defined in
+
+[src/types.ts:445](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L445)
+
+***
+
+### items
+
+> **items**: [`LabeledDatasetItem`](LabeledDatasetItem.md)[]
+
+Items in the dataset
+
+#### Defined in
+
+[src/types.ts:448](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L448)
+
+***
+
+### name
+
+> **name**: `string`
+
+Dataset name
+
+#### Defined in
+
+[src/types.ts:439](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L439)
+
+***
+
+### response\_count
+
+> **response\_count**: `number`
+
+Number of items included in the response
+
+#### Defined in
+
+[src/types.ts:451](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L451)
+
+***
+
+### schema
+
+> **schema**: `null` \| [`DatasetSchema`](DatasetSchema.md)
+
+Dataset schema
+
+#### Defined in
+
+[src/types.ts:442](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L442)
+
+***
+
+### total\_count
+
+> **total\_count**: `number`
+
+Total number of items in the dataset
+
+#### Defined in
+
+[src/types.ts:454](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L454)

--- a/docs/types/interfaces/DatasetFromList.md
+++ b/docs/types/interfaces/DatasetFromList.md
@@ -1,0 +1,91 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetFromList
+
+# Interface: DatasetFromList
+
+## Properties
+
+### created\_at
+
+> **created\_at**: `string`
+
+Date the dataset was created
+
+#### Defined in
+
+[src/types.ts:416](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L416)
+
+***
+
+### dataset\_name
+
+> **dataset\_name**: `string`
+
+Dataset name
+
+#### Defined in
+
+[src/types.ts:413](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L413)
+
+***
+
+### dataset\_schema
+
+> **dataset\_schema**: [`DatasetSchema`](DatasetSchema.md)
+
+Dataset schema
+
+#### Defined in
+
+[src/types.ts:425](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L425)
+
+***
+
+### id
+
+> **id**: `string`
+
+Dataset ID
+
+#### Defined in
+
+[src/types.ts:410](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L410)
+
+***
+
+### ingest\_status
+
+> **ingest\_status**: `null` \| `string`
+
+Ingest status
+
+#### Defined in
+
+[src/types.ts:422](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L422)
+
+***
+
+### source
+
+> **source**: `string`
+
+Source of the dataset
+
+#### Defined in
+
+[src/types.ts:428](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L428)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `null` \| `string`
+
+Date the dataset was last updated
+
+#### Defined in
+
+[src/types.ts:419](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L419)

--- a/docs/types/interfaces/DatasetItemLabel.md
+++ b/docs/types/interfaces/DatasetItemLabel.md
@@ -1,0 +1,177 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetItemLabel
+
+# Interface: DatasetItemLabel
+
+Label for an item
+
+## Properties
+
+### confidence
+
+> **confidence**: `null` \| `number`
+
+Confidence score
+
+#### Defined in
+
+[src/types.ts:253](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L253)
+
+***
+
+### created\_by
+
+> **created\_by**: `null` \| `string`
+
+User who created the label
+
+#### Defined in
+
+[src/types.ts:256](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L256)
+
+***
+
+### error\_msg
+
+> **error\_msg**: `null` \| `string`
+
+Error message if the label creation failed
+
+#### Defined in
+
+[src/types.ts:259](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L259)
+
+***
+
+### expected\_label
+
+> **expected\_label**: `null` \| `string`
+
+Expected label (either from ground truth in dataset or human verified value)
+
+#### Defined in
+
+[src/types.ts:262](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L262)
+
+***
+
+### explanation
+
+> **explanation**: `null` \| `string`
+
+An explanation of the labeling decision
+
+#### Defined in
+
+[src/types.ts:265](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L265)
+
+***
+
+### id
+
+> **id**: `string`
+
+Related subtask ID
+
+#### Defined in
+
+[src/types.ts:268](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L268)
+
+***
+
+### label
+
+> **label**: `string`
+
+Label value
+
+#### Defined in
+
+[src/types.ts:271](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L271)
+
+***
+
+### llm\_label
+
+> **llm\_label**: `null` \| `string`
+
+Original label from the LLM
+
+#### Defined in
+
+[src/types.ts:274](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L274)
+
+***
+
+### multilabel\_confidence
+
+> **multilabel\_confidence**: `null` \| `Record`\<`string`, `number`\>
+
+Multilabel confidence
+
+#### Defined in
+
+[src/types.ts:277](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L277)
+
+***
+
+### overridden
+
+> **overridden**: `boolean`
+
+Whether the label was overridden
+
+#### Defined in
+
+[src/types.ts:280](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L280)
+
+***
+
+### raw\_confidence
+
+> **raw\_confidence**: `null` \| `number`
+
+Uncalibrated confidence score
+
+#### Defined in
+
+[src/types.ts:283](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L283)
+
+***
+
+### raw\_response
+
+> **raw\_response**: `null` \| `string`
+
+Raw response from the LLM
+
+#### Defined in
+
+[src/types.ts:286](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L286)
+
+***
+
+### selected\_labels
+
+> **selected\_labels**: `null` \| `string`[]
+
+List of labels the LLM selected from
+
+#### Defined in
+
+[src/types.ts:289](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L289)
+
+***
+
+### source
+
+> **source**: [`LabelSource`](../enumerations/LabelSource.md)
+
+The source of the label
+
+#### Defined in
+
+[src/types.ts:292](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L292)

--- a/docs/types/interfaces/DatasetItemLabels.md
+++ b/docs/types/interfaces/DatasetItemLabels.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetItemLabels
+
+# Interface: DatasetItemLabels
+
+Labels for an item
+
+## Indexable
+
+ \[`subtaskId`: `string`\]: [`DatasetItemLabel`](DatasetItemLabel.md)

--- a/docs/types/interfaces/DatasetItemLabelsUpdate.md
+++ b/docs/types/interfaces/DatasetItemLabelsUpdate.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetItemLabelsUpdate
+
+# Interface: DatasetItemLabelsUpdate
+
+Data to update labels for an item
+
+## Indexable
+
+ \[`subtaskId`: `string`\]: [`DatasetItemLabelUpdateData`](../type-aliases/DatasetItemLabelUpdateData.md)

--- a/docs/types/interfaces/DatasetItemsOptions.md
+++ b/docs/types/interfaces/DatasetItemsOptions.md
@@ -1,0 +1,57 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetItemsOptions
+
+# Interface: DatasetItemsOptions
+
+Options for getting dataset items
+
+## Properties
+
+### filters?
+
+> `optional` **filters**: [`SQLFilter`](SQLFilter.md)[]
+
+Filters to apply to the dataset
+
+#### Defined in
+
+[src/types.ts:1025](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1025)
+
+***
+
+### maxItems?
+
+> `optional` **maxItems**: `number`
+
+Maximum number of items to return
+
+#### Defined in
+
+[src/types.ts:1028](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1028)
+
+***
+
+### offset?
+
+> `optional` **offset**: `number`
+
+Offset to start the items at
+
+#### Defined in
+
+[src/types.ts:1031](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1031)
+
+***
+
+### orderBy?
+
+> `optional` **orderBy**: `string`[]
+
+Order by
+
+#### Defined in
+
+[src/types.ts:1034](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1034)

--- a/docs/types/interfaces/DatasetSchema.md
+++ b/docs/types/interfaces/DatasetSchema.md
@@ -1,0 +1,45 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetSchema
+
+# Interface: DatasetSchema
+
+The schema for a dataset
+
+## Properties
+
+### $schema
+
+> **$schema**: `string`
+
+The schema URI
+
+#### Defined in
+
+[src/types.ts:405](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L405)
+
+***
+
+### properties
+
+> **properties**: `Record`\<`string`, [`DatasetSchemaColumn`](DatasetSchemaColumn.md)\>
+
+Properties in the schema
+
+#### Defined in
+
+[src/types.ts:399](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L399)
+
+***
+
+### type
+
+> **type**: `string`
+
+Type of the schema
+
+#### Defined in
+
+[src/types.ts:402](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L402)

--- a/docs/types/interfaces/DatasetSchemaColumn.md
+++ b/docs/types/interfaces/DatasetSchemaColumn.md
@@ -1,0 +1,45 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetSchemaColumn
+
+# Interface: DatasetSchemaColumn
+
+A column in the dataset schema
+
+## Properties
+
+### name
+
+> **name**: `string`
+
+Column name
+
+#### Defined in
+
+[src/types.ts:385](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L385)
+
+***
+
+### order
+
+> **order**: `number`
+
+Order of the column
+
+#### Defined in
+
+[src/types.ts:391](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L391)
+
+***
+
+### type
+
+> **type**: [`DatasetColumnType`](../enumerations/DatasetColumnType.md)
+
+Column type
+
+#### Defined in
+
+[src/types.ts:388](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L388)

--- a/docs/types/interfaces/EvaluationStat.md
+++ b/docs/types/interfaces/EvaluationStat.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / EvaluationStat
+
+# Interface: EvaluationStat
+
+Evaluation statistics for a model
+
+## Properties
+
+### metrics?
+
+> `optional` **metrics**: `null` \| [`TaskRunMetrics`](TaskRunMetrics.md)
+
+Metrics for the task run
+
+#### Defined in
+
+[src/types.ts:1090](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1090)
+
+***
+
+### model?
+
+> `optional` **model**: `null` \| `string`
+
+Model ID
+
+#### Defined in
+
+[src/types.ts:1093](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1093)

--- a/docs/types/interfaces/ExportDatasetOptions.md
+++ b/docs/types/interfaces/ExportDatasetOptions.md
@@ -1,0 +1,81 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ExportDatasetOptions
+
+# Interface: ExportDatasetOptions
+
+Options for exporting a dataset
+
+## Properties
+
+### email?
+
+> `optional` **email**: `string`
+
+Email to send the export to
+
+#### Defined in
+
+[src/types.ts:991](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L991)
+
+***
+
+### filters?
+
+> `optional` **filters**: [`SQLFilter`](SQLFilter.md)[]
+
+Filters to apply to the dataset
+
+#### Defined in
+
+[src/types.ts:994](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L994)
+
+***
+
+### includeLabels?
+
+> `optional` **includeLabels**: `boolean`
+
+Whether to include labels in the export
+
+#### Defined in
+
+[src/types.ts:997](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L997)
+
+***
+
+### includeUUID?
+
+> `optional` **includeUUID**: `boolean`
+
+Whether to include the Refuel UUID in the export
+
+#### Defined in
+
+[src/types.ts:1000](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1000)
+
+***
+
+### taskId?
+
+> `optional` **taskId**: `string`
+
+Task ID
+
+#### Defined in
+
+[src/types.ts:1003](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1003)
+
+***
+
+### taskRunId?
+
+> `optional` **taskRunId**: `string`
+
+Task run ID
+
+#### Defined in
+
+[src/types.ts:1006](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1006)

--- a/docs/types/interfaces/ExportDatasetResponse.md
+++ b/docs/types/interfaces/ExportDatasetResponse.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ExportDatasetResponse
+
+# Interface: ExportDatasetResponse
+
+Response from exporting a dataset
+
+## Properties
+
+### export\_id
+
+> **export\_id**: `string`
+
+ID of the export
+
+#### Defined in
+
+[src/types.ts:1014](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1014)
+
+***
+
+### uri
+
+> **uri**: `string`
+
+URI of the export
+
+#### Defined in
+
+[src/types.ts:1017](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1017)

--- a/docs/types/interfaces/FinetuningHyperparameters.md
+++ b/docs/types/interfaces/FinetuningHyperparameters.md
@@ -1,0 +1,61 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FinetuningHyperparameters
+
+# Interface: FinetuningHyperparameters
+
+Finetuning hyperparameters
+
+## Properties
+
+### adapter?
+
+> `optional` **adapter**: `string`
+
+#### Defined in
+
+[src/types.ts:1100](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1100)
+
+***
+
+### learning\_rate\_multiplier
+
+> **learning\_rate\_multiplier**: `number`
+
+Adjusts how fast the model learns — the higher it
+is, the quicker it adapts but with increased risk of
+instability
+
+#### Defined in
+
+[src/types.ts:1107](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1107)
+
+***
+
+### lora\_r?
+
+> `optional` **lora\_r**: `8` \| `16` \| `32` \| `64`
+
+Sets how much the model adapts during finetuning —
+the higher the rank, the more complex patterns it
+can learn, but it also requires more training data
+to avoid overfitting
+
+#### Defined in
+
+[src/types.ts:1115](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1115)
+
+***
+
+### num\_epochs
+
+> **num\_epochs**: `number`
+
+Sets the number of times the model will go through
+the entire training data to improve its learning
+
+#### Defined in
+
+[src/types.ts:1121](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1121)

--- a/docs/types/interfaces/FinetuningRunStage.md
+++ b/docs/types/interfaces/FinetuningRunStage.md
@@ -1,0 +1,57 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FinetuningRunStage
+
+# Interface: FinetuningRunStage
+
+A stage in the finetuning run timeline
+
+## Properties
+
+### detail
+
+> **detail**: `null` \| `string`
+
+Stage details
+
+#### Defined in
+
+[src/types.ts:1129](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1129)
+
+***
+
+### index
+
+> **index**: `number`
+
+Stage index
+
+#### Defined in
+
+[src/types.ts:1132](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1132)
+
+***
+
+### stage\_id
+
+> **stage\_id**: `string`
+
+Stage ID
+
+#### Defined in
+
+[src/types.ts:1135](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1135)
+
+***
+
+### status
+
+> **status**: `"NOT STARTED"` \| `"IN PROGRESS"` \| `"COMPLETED"` \| `"FAILED"`
+
+Stage status
+
+#### Defined in
+
+[src/types.ts:1138](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1138)

--- a/docs/types/interfaces/Integration.md
+++ b/docs/types/interfaces/Integration.md
@@ -1,0 +1,105 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Integration
+
+# Interface: Integration
+
+An integration with an external service
+
+## Properties
+
+### category
+
+> **category**: `string`
+
+Integration category
+
+#### Defined in
+
+[src/types.ts:968](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L968)
+
+***
+
+### config
+
+> **config**: [`IntegrationConfig`](../type-aliases/IntegrationConfig.md)
+
+Integration configuration
+
+#### Defined in
+
+[src/types.ts:980](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L980)
+
+***
+
+### description
+
+> **description**: `string`
+
+Integration description
+
+#### Defined in
+
+[src/types.ts:971](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L971)
+
+***
+
+### id
+
+> **id**: `string`
+
+Integration ID
+
+#### Defined in
+
+[src/types.ts:962](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L962)
+
+***
+
+### is\_available
+
+> **is\_available**: `boolean`
+
+Whether the integration is available
+
+#### Defined in
+
+[src/types.ts:977](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L977)
+
+***
+
+### is\_connected
+
+> **is\_connected**: `boolean`
+
+Whether the integration is connected
+
+#### Defined in
+
+[src/types.ts:974](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L974)
+
+***
+
+### logo\_url
+
+> **logo\_url**: `string`
+
+URL to the logo of the external service
+
+#### Defined in
+
+[src/types.ts:983](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L983)
+
+***
+
+### name
+
+> **name**: `string`
+
+Name of the external service
+
+#### Defined in
+
+[src/types.ts:965](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L965)

--- a/docs/types/interfaces/InviteUsersResponse.md
+++ b/docs/types/interfaces/InviteUsersResponse.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / InviteUsersResponse
+
+# Interface: InviteUsersResponse
+
+Response from inviting users to the team
+
+## Properties
+
+### failed
+
+> **failed**: `string`[]
+
+Users that failed to be invited
+
+#### Defined in
+
+[src/types.ts:884](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L884)
+
+***
+
+### success
+
+> **success**: `string`[]
+
+Users that were invited
+
+#### Defined in
+
+[src/types.ts:887](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L887)

--- a/docs/types/interfaces/LabelListOptions.md
+++ b/docs/types/interfaces/LabelListOptions.md
@@ -1,0 +1,69 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / LabelListOptions
+
+# Interface: LabelListOptions
+
+Options for listing labels for an item
+
+## Properties
+
+### generateMissingExplanations?
+
+> `optional` **generateMissingExplanations**: `boolean`
+
+Generate explanations for the label
+
+#### Default
+
+```ts
+false
+```
+
+#### Defined in
+
+[src/types.ts:1413](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1413)
+
+***
+
+### generateMissingLabels?
+
+> `optional` **generateMissingLabels**: `boolean`
+
+Generate the label if it is missing
+
+#### Default
+
+```ts
+false
+```
+
+#### Defined in
+
+[src/types.ts:1406](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1406)
+
+***
+
+### modelId?
+
+> `optional` **modelId**: `string`
+
+Override the model used for labeling
+
+#### Defined in
+
+[src/types.ts:1396](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1396)
+
+***
+
+### subtaskId?
+
+> `optional` **subtaskId**: `string`
+
+Specify the subtask to label
+
+#### Defined in
+
+[src/types.ts:1399](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1399)

--- a/docs/types/interfaces/LabeledDatasetItem.md
+++ b/docs/types/interfaces/LabeledDatasetItem.md
@@ -1,0 +1,57 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / LabeledDatasetItem
+
+# Interface: LabeledDatasetItem
+
+Item in a dataset
+
+## Properties
+
+### fields
+
+> **fields**: `null` \| `Record`\<`string`, `unknown`\>
+
+Fields and their values
+
+#### Defined in
+
+[src/types.ts:327](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L327)
+
+***
+
+### in\_evalset
+
+> **in\_evalset**: `boolean`
+
+Whether the item is in the eval set
+
+#### Defined in
+
+[src/types.ts:336](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L336)
+
+***
+
+### labels
+
+> **labels**: `null` \| [`DatasetItemLabels`](DatasetItemLabels.md)
+
+Labels for the item
+
+#### Defined in
+
+[src/types.ts:330](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L330)
+
+***
+
+### telemetry
+
+> **telemetry**: `null` \| [`Telemetry`](Telemetry.md)[]
+
+Telemetry for the item (e.g. how many tokens were used)
+
+#### Defined in
+
+[src/types.ts:333](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L333)

--- a/docs/types/interfaces/LabelingModel.md
+++ b/docs/types/interfaces/LabelingModel.md
@@ -1,0 +1,255 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / LabelingModel
+
+# Interface: LabelingModel
+
+LLM labeling model
+
+## Properties
+
+### augmented\_finetuning\_model
+
+> **augmented\_finetuning\_model**: `null` \| `string`
+
+Generate labels with this model and include them in the training data
+
+#### Defined in
+
+[src/types.ts:1195](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1195)
+
+***
+
+### availability\_status
+
+> **availability\_status**: [`AvailabilityStatus`](../enumerations/AvailabilityStatus.md)
+
+Availability status
+
+#### Defined in
+
+[src/types.ts:1192](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1192)
+
+***
+
+### base\_model
+
+> **base\_model**: `string`
+
+Base model
+
+#### Defined in
+
+[src/types.ts:1198](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1198)
+
+***
+
+### comparison\_model?
+
+> `optional` **comparison\_model**: `null` \| `string`
+
+Model to evaluate the finetuned model against
+
+#### Defined in
+
+[src/types.ts:1201](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1201)
+
+***
+
+### created\_at
+
+> **created\_at**: `null` \| `string`
+
+Date the labeling model was created
+
+#### Defined in
+
+[src/types.ts:1204](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1204)
+
+***
+
+### datasets
+
+> **datasets**: `string`[]
+
+Datasets the labeling model is associated with
+
+#### Defined in
+
+[src/types.ts:1207](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1207)
+
+***
+
+### evaluation\_stats
+
+> **evaluation\_stats**: [`EvaluationStat`](EvaluationStat.md)[]
+
+Evaluation statistics
+
+#### Defined in
+
+[src/types.ts:1210](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1210)
+
+***
+
+### finetuning\_run\_status
+
+> **finetuning\_run\_status**: `null` \| [`FinetuningRunStatus`](../enumerations/FinetuningRunStatus.md)
+
+Finetuning run status
+
+#### Defined in
+
+[src/types.ts:1213](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1213)
+
+***
+
+### finetuning\_run\_timeline
+
+> **finetuning\_run\_timeline**: `null` \| [`FinetuningRunStage`](FinetuningRunStage.md)[]
+
+Finetuning run timeline
+
+#### Defined in
+
+[src/types.ts:1216](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1216)
+
+***
+
+### hyperparameters
+
+> **hyperparameters**: `null` \| [`FinetuningHyperparameters`](FinetuningHyperparameters.md)
+
+Finetuning hyperparameters
+
+#### Defined in
+
+[src/types.ts:1219](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1219)
+
+***
+
+### id
+
+> **id**: `string`
+
+Labeling model ID
+
+#### Defined in
+
+[src/types.ts:1189](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1189)
+
+***
+
+### lora
+
+> **lora**: `boolean`
+
+Whether to use LoRA finetuning
+
+#### Defined in
+
+[src/types.ts:1222](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1222)
+
+***
+
+### name
+
+> **name**: `string`
+
+Labeling model name
+
+#### Defined in
+
+[src/types.ts:1225](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1225)
+
+***
+
+### project\_id
+
+> **project\_id**: `null` \| `string`
+
+Project ID
+
+#### Defined in
+
+[src/types.ts:1228](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1228)
+
+***
+
+### provider
+
+> **provider**: `string`
+
+Provider
+
+#### Defined in
+
+[src/types.ts:1231](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1231)
+
+***
+
+### task\_id
+
+> **task\_id**: `null` \| `string`
+
+Task ID
+
+#### Defined in
+
+[src/types.ts:1234](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1234)
+
+***
+
+### training\_stats
+
+> **training\_stats**: `null` \| \{ `checkpoint_index`: `number`[]; `evaluation_loss`: `null` \| [`number`, `number`][]; `training_loss`: `null` \| [`number`, `number`][]; \}
+
+Training statistics
+
+#### Type declaration
+
+`null`
+
+\{ `checkpoint_index`: `number`[]; `evaluation_loss`: `null` \| [`number`, `number`][]; `training_loss`: `null` \| [`number`, `number`][]; \}
+
+#### checkpoint\_index
+
+> **checkpoint\_index**: `number`[]
+
+Points during training where the model's
+progress was saved, useful for tracking
+and correlating loss values.
+
+#### evaluation\_loss
+
+> **evaluation\_loss**: `null` \| [`number`, `number`][]
+
+Measures the model's performance on unseen
+data to detect overfitting, ideally decreasing
+along with training loss.
+
+#### training\_loss
+
+> **training\_loss**: `null` \| [`number`, `number`][]
+
+Shows how well the model is learning from
+the training data over time, with lower
+values indicating better performance
+
+#### Defined in
+
+[src/types.ts:1237](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1237)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `null` \| `string`
+
+Date the labeling model was last updated
+
+#### Defined in
+
+[src/types.ts:1261](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1261)

--- a/docs/types/interfaces/Metadata.md
+++ b/docs/types/interfaces/Metadata.md
@@ -1,0 +1,81 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Metadata
+
+# Interface: Metadata
+
+Metadata for a column
+
+## Properties
+
+### existingLabelTaskIds?
+
+> `optional` **existingLabelTaskIds**: `null` \| `string`[]
+
+Existing label task IDs
+
+#### Defined in
+
+[src/types.ts:344](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L344)
+
+***
+
+### is\_confidence
+
+> **is\_confidence**: `null` \| `boolean`
+
+Whether the column is a confidence score
+
+#### Defined in
+
+[src/types.ts:347](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L347)
+
+***
+
+### is\_llm\_label
+
+> **is\_llm\_label**: `null` \| `boolean`
+
+Whether the column is an LLM label
+
+#### Defined in
+
+[src/types.ts:350](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L350)
+
+***
+
+### source
+
+> **source**: `null` \| `"refuel"` \| `"user"`
+
+Source of the column value
+
+#### Defined in
+
+[src/types.ts:353](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L353)
+
+***
+
+### taskId
+
+> **taskId**: `null` \| `string`
+
+Task ID
+
+#### Defined in
+
+[src/types.ts:356](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L356)
+
+***
+
+### type
+
+> **type**: `"string"` \| `"boolean"` \| `"integer"` \| `"date"`
+
+Type of the column value
+
+#### Defined in
+
+[src/types.ts:359](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L359)

--- a/docs/types/interfaces/MetricResult.md
+++ b/docs/types/interfaces/MetricResult.md
@@ -1,0 +1,69 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / MetricResult
+
+# Interface: MetricResult
+
+A metric result
+
+## Properties
+
+### name
+
+> **name**: `string`
+
+Metric name
+
+#### Defined in
+
+[src/types.ts:1059](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1059)
+
+***
+
+### subtaskId
+
+> **subtaskId**: `string`
+
+Subtask ID
+
+#### Defined in
+
+[src/types.ts:1071](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1071)
+
+***
+
+### support
+
+> **support**: `number`
+
+Support
+
+#### Defined in
+
+[src/types.ts:1068](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1068)
+
+***
+
+### type
+
+> **type**: [`MetricFormat`](../enumerations/MetricFormat.md)
+
+Metric type
+
+#### Defined in
+
+[src/types.ts:1065](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1065)
+
+***
+
+### value
+
+> **value**: `unknown`
+
+Metric value
+
+#### Defined in
+
+[src/types.ts:1062](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1062)

--- a/docs/types/interfaces/Project.md
+++ b/docs/types/interfaces/Project.md
@@ -1,0 +1,81 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Project
+
+# Interface: Project
+
+Project for your team
+
+## Properties
+
+### created\_at
+
+> **created\_at**: `string`
+
+Date the project was created
+
+#### Defined in
+
+[src/types.ts:211](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L211)
+
+***
+
+### description?
+
+> `optional` **description**: `string`
+
+Project description
+
+#### Defined in
+
+[src/types.ts:214](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L214)
+
+***
+
+### id
+
+> **id**: `string`
+
+Project ID
+
+#### Defined in
+
+[src/types.ts:208](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L208)
+
+***
+
+### project\_name
+
+> **project\_name**: `string`
+
+Project name
+
+#### Defined in
+
+[src/types.ts:217](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L217)
+
+***
+
+### team
+
+> **team**: `null` \| `string`
+
+Team the project is associated with
+
+#### Defined in
+
+[src/types.ts:220](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L220)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `string`
+
+Date the project was last updated
+
+#### Defined in
+
+[src/types.ts:223](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L223)

--- a/docs/types/interfaces/ProjectData.md
+++ b/docs/types/interfaces/ProjectData.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / ProjectData
+
+# Interface: ProjectData
+
+Data to create a project
+
+## Properties
+
+### description?
+
+> `optional` **description**: `string`
+
+Project description
+
+#### Defined in
+
+[src/types.ts:200](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L200)
+
+***
+
+### project\_name
+
+> **project\_name**: `string`
+
+Project name
+
+#### Defined in
+
+[src/types.ts:197](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L197)

--- a/docs/types/interfaces/RefuelTeam.md
+++ b/docs/types/interfaces/RefuelTeam.md
@@ -1,0 +1,59 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / RefuelTeam
+
+# Interface: RefuelTeam
+
+Team for your organization
+
+## Properties
+
+### created\_at
+
+> **created\_at**: `string`
+
+Date the team was created
+
+#### Defined in
+
+[src/types.ts:807](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L807)
+
+***
+
+### feature\_flags
+
+> **feature\_flags**: `null` \| `Record`\<`string`, [`FeatureFlagValues`](../enumerations/FeatureFlagValues.md)\>
+
+Feature flags for the team
+
+#### Defined in
+
+[src/types.ts:810](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L810)
+
+***
+
+### name
+
+> **name**: `string`
+
+Team name
+
+#### Defined in
+
+[src/types.ts:813](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L813)
+
+***
+
+### refuel\_api\_key
+
+> **refuel\_api\_key**: `string`
+
+Refuel API key
+
+This can be used to authenticate requests to the Refuel API or with the Refuel SDKs
+
+#### Defined in
+
+[src/types.ts:819](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L819)

--- a/docs/types/interfaces/RequestOptions.md
+++ b/docs/types/interfaces/RequestOptions.md
@@ -1,0 +1,91 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / RequestOptions
+
+# Interface: RequestOptions\<T\>
+
+Options for a request to the Refuel API
+
+## Type Parameters
+
+• **T**
+
+## Properties
+
+### data?
+
+> `optional` **data**: `T`
+
+Data to send in the body of the request
+
+#### Defined in
+
+[src/types.ts:17](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L17)
+
+***
+
+### initialRetryTimeout?
+
+> `optional` **initialRetryTimeout**: `number`
+
+Initial retry timeout (in milliseconds)
+
+#### Defined in
+
+[src/types.ts:23](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L23)
+
+***
+
+### maxRetries?
+
+> `optional` **maxRetries**: `number`
+
+Maximum number of retries
+
+#### Defined in
+
+[src/types.ts:26](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L26)
+
+***
+
+### method?
+
+> `optional` **method**: `string`
+
+HTTP method to use
+
+#### Default
+
+```ts
+"GET"
+```
+
+#### Defined in
+
+[src/types.ts:14](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L14)
+
+***
+
+### retries?
+
+> `optional` **retries**: `number`
+
+Number of retries attempted
+
+#### Defined in
+
+[src/types.ts:20](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L20)
+
+***
+
+### retryStatusCodes?
+
+> `optional` **retryStatusCodes**: `number`[]
+
+Status codes to retry on
+
+#### Defined in
+
+[src/types.ts:29](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L29)

--- a/docs/types/interfaces/SQLFilter.md
+++ b/docs/types/interfaces/SQLFilter.md
@@ -1,0 +1,81 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / SQLFilter
+
+# Interface: SQLFilter
+
+A filter to apply to a dataset or task run
+
+## Properties
+
+### field
+
+> **field**: `string`
+
+Field to filter on
+
+#### Defined in
+
+[src/types.ts:554](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L554)
+
+***
+
+### filter\_type
+
+> **filter\_type**: [`FilterFieldCategory`](../enumerations/FilterFieldCategory.md)
+
+Filter type
+
+#### Defined in
+
+[src/types.ts:551](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L551)
+
+***
+
+### operator
+
+> **operator**: [`FilterOperator`](../enumerations/FilterOperator.md)
+
+Operator to use
+
+#### Defined in
+
+[src/types.ts:557](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L557)
+
+***
+
+### subtask\_id?
+
+> `optional` **subtask\_id**: `string`
+
+Subtask ID
+
+#### Defined in
+
+[src/types.ts:566](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L566)
+
+***
+
+### value?
+
+> `optional` **value**: `string` \| `string`[]
+
+Value to filter on
+
+#### Defined in
+
+[src/types.ts:563](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L563)
+
+***
+
+### value\_type?
+
+> `optional` **value\_type**: [`FilterValueType`](../type-aliases/FilterValueType.md)
+
+Value type
+
+#### Defined in
+
+[src/types.ts:560](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L560)

--- a/docs/types/interfaces/Subtask.md
+++ b/docs/types/interfaces/Subtask.md
@@ -1,0 +1,179 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Subtask
+
+# Interface: Subtask
+
+## Properties
+
+### default\_value?
+
+> `optional` **default\_value**: `null` \| `string`
+
+Default value
+
+#### Defined in
+
+[src/types.ts:587](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L587)
+
+***
+
+### guidelines
+
+> **guidelines**: `null` \| `string`
+
+Guidelines
+
+#### Defined in
+
+[src/types.ts:590](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L590)
+
+***
+
+### id
+
+> **id**: `string`
+
+Subtask ID
+
+#### Defined in
+
+[src/types.ts:584](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L584)
+
+***
+
+### image\_columns
+
+> **image\_columns**: `null` \| `string`[]
+
+Columns with a URL to an image
+
+#### Defined in
+
+[src/types.ts:593](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L593)
+
+***
+
+### input\_columns
+
+> **input\_columns**: `null` \| `string`[]
+
+Input columns
+
+#### Defined in
+
+[src/types.ts:596](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L596)
+
+***
+
+### label\_column
+
+> **label\_column**: `null` \| `string`
+
+Ground truth column
+
+#### Defined in
+
+[src/types.ts:599](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L599)
+
+***
+
+### label\_selection?
+
+> `optional` **label\_selection**: `null` \| `number`
+
+Number of labels to send to the LLM to select from
+
+#### Defined in
+
+[src/types.ts:602](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L602)
+
+***
+
+### labels
+
+> **labels**: `null` \| `string`[]
+
+Labels
+
+#### Defined in
+
+[src/types.ts:605](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L605)
+
+***
+
+### name
+
+> **name**: `null` \| `string`
+
+Subtask name
+
+#### Defined in
+
+[src/types.ts:608](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L608)
+
+***
+
+### order?
+
+> `optional` **order**: `null` \| `number`
+
+Order of the subtask
+
+#### Defined in
+
+[src/types.ts:611](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L611)
+
+***
+
+### schema?
+
+> `optional` **schema**: `null` \| `string`
+
+JSON Schema the LLM output must conform to
+
+#### See
+
+[https://platform.openai.com/docs/guides/structured-outputs#supported-schemas](https://platform.openai.com/docs/guides/structured-outputs#supported-schemas)
+
+#### Defined in
+
+[src/types.ts:622](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L622)
+
+***
+
+### schema\_guidelines\_hash?
+
+> `optional` **schema\_guidelines\_hash**: `null` \| `string`
+
+Hash of the guidelines used to generate the schema
+
+#### Defined in
+
+[src/types.ts:614](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L614)
+
+***
+
+### schema\_mode?
+
+> `optional` **schema\_mode**: `null` \| [`SchemaMode`](../enumerations/SchemaMode.md)
+
+Schema mode
+
+#### Defined in
+
+[src/types.ts:617](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L617)
+
+***
+
+### type
+
+> **type**: `null` \| [`TaskType`](../enumerations/TaskType.md)
+
+Subtask type
+
+#### Defined in
+
+[src/types.ts:625](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L625)

--- a/docs/types/interfaces/Task.md
+++ b/docs/types/interfaces/Task.md
@@ -1,0 +1,251 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Task
+
+# Interface: Task
+
+Labeling task
+
+## Properties
+
+### compute\_confidence
+
+> **compute\_confidence**: `boolean`
+
+Whether to compute confidence scores
+
+#### Defined in
+
+[src/types.ts:697](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L697)
+
+***
+
+### context
+
+> **context**: `null` \| `string`
+
+Context for the LLM to use when labeling
+
+#### Defined in
+
+[src/types.ts:700](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L700)
+
+***
+
+### created\_at
+
+> **created\_at**: `null` \| `string`
+
+Date the task was created
+
+#### Defined in
+
+[src/types.ts:703](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L703)
+
+***
+
+### dataset\_id
+
+> **dataset\_id**: `null` \| `string`
+
+Dataset ID
+
+#### Defined in
+
+[src/types.ts:706](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L706)
+
+***
+
+### deployed
+
+> **deployed**: `null` \| `boolean`
+
+Whether the task is deployed as an application
+
+#### Defined in
+
+[src/types.ts:709](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L709)
+
+***
+
+### description
+
+> **description**: `null` \| `string`
+
+Description of the task
+
+#### Defined in
+
+[src/types.ts:712](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L712)
+
+***
+
+### emoji
+
+> **emoji**: `null` \| `string`
+
+Emoji for the task
+
+#### Defined in
+
+[src/types.ts:715](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L715)
+
+***
+
+### few\_shot\_num
+
+> **few\_shot\_num**: `null` \| `number`
+
+Number of few-shot examples to use
+
+#### Defined in
+
+[src/types.ts:718](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L718)
+
+***
+
+### id
+
+> **id**: `null` \| `string`
+
+Task ID
+
+#### Defined in
+
+[src/types.ts:694](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L694)
+
+***
+
+### mutable
+
+> **mutable**: `boolean`
+
+Whether the task is mutable
+
+#### Defined in
+
+[src/types.ts:721](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L721)
+
+***
+
+### project\_id
+
+> **project\_id**: `null` \| `string`
+
+Project ID
+
+#### Defined in
+
+[src/types.ts:724](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L724)
+
+***
+
+### runnable
+
+> **runnable**: `boolean`
+
+Whether the task is runnable
+
+#### Defined in
+
+[src/types.ts:727](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L727)
+
+***
+
+### selected\_model\_id
+
+> **selected\_model\_id**: `null` \| `string`
+
+Selected model ID
+
+#### Defined in
+
+[src/types.ts:730](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L730)
+
+***
+
+### subtasks
+
+> **subtasks**: `null` \| `Partial`\<[`Subtask`](Subtask.md)\>[]
+
+Subtasks
+
+#### Defined in
+
+[src/types.ts:733](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L733)
+
+***
+
+### task\_name
+
+> **task\_name**: `null` \| `string`
+
+Task name
+
+#### Defined in
+
+[src/types.ts:736](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L736)
+
+***
+
+### task\_type
+
+> **task\_type**: `null` \| [`TaskType`](../enumerations/TaskType.md)
+
+Task type
+
+#### Defined in
+
+[src/types.ts:739](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L739)
+
+***
+
+### transforms?
+
+> `optional` **transforms**: `null` \| `Partial`\<[`Transform`](Transform.md)\>[]
+
+Transforms
+
+#### Defined in
+
+[src/types.ts:742](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L742)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `null` \| `string`
+
+Date the task was last updated
+
+#### Defined in
+
+[src/types.ts:745](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L745)
+
+***
+
+### use\_beam\_search
+
+> **use\_beam\_search**: `null` \| `boolean`
+
+Whether to use beam search, which tries out
+multiple choices at each step to find the best
+overall result
+
+#### Defined in
+
+[src/types.ts:752](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L752)
+
+***
+
+### use\_llm\_cache
+
+> **use\_llm\_cache**: `null` \| `boolean`
+
+Whether to use the LLM cache
+
+#### Defined in
+
+[src/types.ts:755](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L755)

--- a/docs/types/interfaces/TaskRun.md
+++ b/docs/types/interfaces/TaskRun.md
@@ -1,0 +1,153 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaskRun
+
+# Interface: TaskRun
+
+A task run
+
+## Properties
+
+### created\_at
+
+> **created\_at**: `string`
+
+Date the task run was created
+
+#### Defined in
+
+[src/types.ts:1340](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1340)
+
+***
+
+### dataset\_id
+
+> **dataset\_id**: `string`
+
+Dataset ID
+
+#### Defined in
+
+[src/types.ts:1328](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1328)
+
+***
+
+### dataset\_name
+
+> **dataset\_name**: `string`
+
+Dataset name
+
+#### Defined in
+
+[src/types.ts:1331](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1331)
+
+***
+
+### id
+
+> **id**: `string`
+
+Task run ID
+
+#### Defined in
+
+[src/types.ts:1313](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1313)
+
+***
+
+### is\_eval\_run
+
+> **is\_eval\_run**: `boolean`
+
+Whether the task run is an evaluation run
+
+#### Defined in
+
+[src/types.ts:1337](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1337)
+
+***
+
+### model\_ids
+
+> **model\_ids**: `string`[]
+
+Model(s) used to label the items in this run
+
+#### Defined in
+
+[src/types.ts:1346](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1346)
+
+***
+
+### model\_name
+
+> **model\_name**: `string`
+
+Model name
+
+#### Defined in
+
+[src/types.ts:1325](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1325)
+
+***
+
+### project\_id
+
+> **project\_id**: `string`
+
+Project ID
+
+#### Defined in
+
+[src/types.ts:1316](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1316)
+
+***
+
+### status
+
+> **status**: [`TaskRunStatus`](../type-aliases/TaskRunStatus.md)
+
+Task run status
+
+#### Defined in
+
+[src/types.ts:1334](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1334)
+
+***
+
+### task\_id
+
+> **task\_id**: `string`
+
+Task ID
+
+#### Defined in
+
+[src/types.ts:1319](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1319)
+
+***
+
+### task\_name
+
+> **task\_name**: `string`
+
+Task name
+
+#### Defined in
+
+[src/types.ts:1322](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1322)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `string`
+
+Date the task run was last updated
+
+#### Defined in
+
+[src/types.ts:1343](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1343)

--- a/docs/types/interfaces/TaskRunCancelOptions.md
+++ b/docs/types/interfaces/TaskRunCancelOptions.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaskRunCancelOptions
+
+# Interface: TaskRunCancelOptions
+
+Options for canceling a task run
+
+## Properties
+
+### datasetId?
+
+> `optional` **datasetId**: `string`
+
+Dataset ID
+
+#### Defined in
+
+[src/types.ts:1388](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1388)
+
+***
+
+### evalSet?
+
+> `optional` **evalSet**: `boolean`
+
+Whether this is an evaluation run
+
+#### Defined in
+
+[src/types.ts:1385](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1385)

--- a/docs/types/interfaces/TaskRunCreateOptions.md
+++ b/docs/types/interfaces/TaskRunCreateOptions.md
@@ -1,0 +1,69 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaskRunCreateOptions
+
+# Interface: TaskRunCreateOptions
+
+Options for creating a task run
+
+## Properties
+
+### datasetId?
+
+> `optional` **datasetId**: `string`
+
+Dataset ID
+
+#### Defined in
+
+[src/types.ts:1377](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1377)
+
+***
+
+### evalSet?
+
+> `optional` **evalSet**: `boolean`
+
+Whether to get the eval set
+
+#### Defined in
+
+[src/types.ts:1368](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1368)
+
+***
+
+### filters?
+
+> `optional` **filters**: [`SQLFilter`](SQLFilter.md)[]
+
+Filters to apply to the dataset
+
+#### Defined in
+
+[src/types.ts:1371](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1371)
+
+***
+
+### limit?
+
+> `optional` **limit**: `number`
+
+Maximum number of items to label
+
+#### Defined in
+
+[src/types.ts:1365](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1365)
+
+***
+
+### modelIds?
+
+> `optional` **modelIds**: `string`[]
+
+Model(s) used to label the items in this run
+
+#### Defined in
+
+[src/types.ts:1374](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1374)

--- a/docs/types/interfaces/TaskRunListOptions.md
+++ b/docs/types/interfaces/TaskRunListOptions.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaskRunListOptions
+
+# Interface: TaskRunListOptions
+
+Options for getting task runs
+
+## Properties
+
+### datasetId?
+
+> `optional` **datasetId**: `string`
+
+Dataset ID
+
+#### Defined in
+
+[src/types.ts:1354](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1354)
+
+***
+
+### evalSet?
+
+> `optional` **evalSet**: `boolean`
+
+Whether to get the eval set
+
+#### Defined in
+
+[src/types.ts:1357](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1357)

--- a/docs/types/interfaces/TaskRunMetrics.md
+++ b/docs/types/interfaces/TaskRunMetrics.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaskRunMetrics
+
+# Interface: TaskRunMetrics
+
+Metrics for a task run
+
+## Properties
+
+### subtasks
+
+> **subtasks**: `null` \| `Record`\<`string`, [`MetricResult`](MetricResult.md)[]\>
+
+Metrics for the subtasks
+
+#### Defined in
+
+[src/types.ts:1082](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1082)
+
+***
+
+### task
+
+> **task**: `null` \| [`MetricResult`](MetricResult.md)[]
+
+Metrics for the overall task
+
+#### Defined in
+
+[src/types.ts:1079](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1079)

--- a/docs/types/interfaces/TaxonomyLabel.md
+++ b/docs/types/interfaces/TaxonomyLabel.md
@@ -1,0 +1,73 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaxonomyLabel
+
+# Interface: TaxonomyLabel
+
+A taxonomy label
+
+## Properties
+
+### description
+
+> **description**: `string`
+
+Label description
+
+#### Defined in
+
+[src/types.ts:901](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L901)
+
+***
+
+### id
+
+> **id**: `string`
+
+Label ID
+
+#### Defined in
+
+[src/types.ts:895](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L895)
+
+***
+
+### level
+
+> **level**: `null` \| `number`
+
+**`Alpha`**
+
+Label level
+
+#### Defined in
+
+[src/types.ts:904](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L904)
+
+***
+
+### name
+
+> **name**: `string`
+
+Label name
+
+#### Defined in
+
+[src/types.ts:898](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L898)
+
+***
+
+### parents
+
+> **parents**: `string`[]
+
+**`Alpha`**
+
+Parent labels
+
+#### Defined in
+
+[src/types.ts:907](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L907)

--- a/docs/types/interfaces/TaxonomyLabelData.md
+++ b/docs/types/interfaces/TaxonomyLabelData.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaxonomyLabelData
+
+# Interface: TaxonomyLabelData
+
+Data to create or update a taxonomy label
+
+## Properties
+
+### description?
+
+> `optional` **description**: `null` \| `string`
+
+Label description
+
+#### Defined in
+
+[src/types.ts:918](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L918)
+
+***
+
+### name
+
+> **name**: `string`
+
+Label name
+
+#### Defined in
+
+[src/types.ts:915](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L915)

--- a/docs/types/interfaces/TaxonomyLabelRequestBody.md
+++ b/docs/types/interfaces/TaxonomyLabelRequestBody.md
@@ -1,0 +1,21 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaxonomyLabelRequestBody
+
+# Interface: TaxonomyLabelRequestBody
+
+Request body to create or update taxonomy labels
+
+## Properties
+
+### labels
+
+> **labels**: [`TaxonomyLabelData`](TaxonomyLabelData.md)[]
+
+Labels to create or update
+
+#### Defined in
+
+[src/types.ts:926](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L926)

--- a/docs/types/interfaces/TaxonomyLabelsResponse.md
+++ b/docs/types/interfaces/TaxonomyLabelsResponse.md
@@ -1,0 +1,81 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaxonomyLabelsResponse
+
+# Interface: TaxonomyLabelsResponse
+
+Response from getting taxonomy labels
+
+## Properties
+
+### created\_at
+
+> **created\_at**: `string`
+
+Date the labels were created
+
+#### Defined in
+
+[src/types.ts:937](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L937)
+
+***
+
+### id
+
+> **id**: `string`
+
+ID of the task the labels are associated with
+
+#### Defined in
+
+[src/types.ts:934](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L934)
+
+***
+
+### labels
+
+> **labels**: [`TaxonomyLabel`](TaxonomyLabel.md)[]
+
+Labels
+
+#### Defined in
+
+[src/types.ts:940](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L940)
+
+***
+
+### task\_id
+
+> **task\_id**: `string`
+
+ID of the task the labels are associated with
+
+#### Defined in
+
+[src/types.ts:943](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L943)
+
+***
+
+### total\_count
+
+> **total\_count**: `number`
+
+Total number of labels
+
+#### Defined in
+
+[src/types.ts:946](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L946)
+
+***
+
+### updated\_at
+
+> **updated\_at**: `string`
+
+Date the labels were last updated
+
+#### Defined in
+
+[src/types.ts:949](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L949)

--- a/docs/types/interfaces/TeamModel.md
+++ b/docs/types/interfaces/TeamModel.md
@@ -1,0 +1,57 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TeamModel
+
+# Interface: TeamModel
+
+LLM model available to a team
+
+## Properties
+
+### display\_name
+
+> **display\_name**: `string`
+
+Model display name
+
+#### Defined in
+
+[src/types.ts:1290](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1290)
+
+***
+
+### name
+
+> **name**: `string`
+
+Model name
+
+#### Defined in
+
+[src/types.ts:1284](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1284)
+
+***
+
+### params
+
+> **params**: `Record`\<`string`, `unknown`\>
+
+Model parameters
+
+#### Defined in
+
+[src/types.ts:1293](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1293)
+
+***
+
+### provider
+
+> **provider**: `string`
+
+Model provider
+
+#### Defined in
+
+[src/types.ts:1287](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1287)

--- a/docs/types/interfaces/Telemetry.md
+++ b/docs/types/interfaces/Telemetry.md
@@ -1,0 +1,43 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Telemetry
+
+# Interface: Telemetry
+
+## Properties
+
+### model\_name
+
+> **model\_name**: `string`
+
+Model name
+
+#### Defined in
+
+[src/types.ts:228](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L228)
+
+***
+
+### telemetry\_type
+
+> **telemetry\_type**: `string`
+
+Type of telemetry (e.g. "input_tokens")
+
+#### Defined in
+
+[src/types.ts:231](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L231)
+
+***
+
+### telemetry\_value
+
+> **telemetry\_value**: `unknown`
+
+Value of the telemetry (e.g. 100)
+
+#### Defined in
+
+[src/types.ts:234](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L234)

--- a/docs/types/interfaces/Transform.md
+++ b/docs/types/interfaces/Transform.md
@@ -1,0 +1,129 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / Transform
+
+# Interface: Transform
+
+An enrichment that can be added to a task
+
+## Extends
+
+- `Pick`\<[`Subtask`](Subtask.md), `"id"` \| `"name"` \| `"guidelines"` \| `"input_columns"` \| `"order"`\>
+
+## Properties
+
+### guidelines
+
+> **guidelines**: `null` \| `string`
+
+Guidelines
+
+#### Inherited from
+
+`Pick.guidelines`
+
+#### Defined in
+
+[src/types.ts:590](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L590)
+
+***
+
+### id
+
+> **id**: `string`
+
+Subtask ID
+
+#### Inherited from
+
+`Pick.id`
+
+#### Defined in
+
+[src/types.ts:584](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L584)
+
+***
+
+### input\_columns
+
+> **input\_columns**: `null` \| `string`[]
+
+Input columns
+
+#### Inherited from
+
+`Pick.input_columns`
+
+#### Defined in
+
+[src/types.ts:596](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L596)
+
+***
+
+### name
+
+> **name**: `null` \| `string`
+
+Subtask name
+
+#### Inherited from
+
+`Pick.name`
+
+#### Defined in
+
+[src/types.ts:608](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L608)
+
+***
+
+### order?
+
+> `optional` **order**: `null` \| `number`
+
+Order of the subtask
+
+#### Inherited from
+
+`Pick.order`
+
+#### Defined in
+
+[src/types.ts:611](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L611)
+
+***
+
+### output\_columns
+
+> **output\_columns**: `null` \| `string`[]
+
+Columns to output
+
+#### Defined in
+
+[src/types.ts:660](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L660)
+
+***
+
+### params
+
+> **params**: `Record`\<`string`, `unknown`\>
+
+Parameters for the enrichment
+
+#### Defined in
+
+[src/types.ts:663](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L663)
+
+***
+
+### type
+
+> **type**: [`TransformType`](../enumerations/TransformType.md)
+
+Type of enrichment
+
+#### Defined in
+
+[src/types.ts:657](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L657)

--- a/docs/types/interfaces/UsageMetric.md
+++ b/docs/types/interfaces/UsageMetric.md
@@ -1,0 +1,69 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / UsageMetric
+
+# Interface: UsageMetric
+
+Telemetry metric for an application or task
+
+## Properties
+
+### application\_id?
+
+> `optional` **application\_id**: `string`
+
+Application ID
+
+#### Defined in
+
+[src/types.ts:763](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L763)
+
+***
+
+### date
+
+> **date**: `string`
+
+Date the metric was recorded
+
+#### Defined in
+
+[src/types.ts:766](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L766)
+
+***
+
+### model\_id?
+
+> `optional` **model\_id**: `string`
+
+Model ID
+
+#### Defined in
+
+[src/types.ts:769](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L769)
+
+***
+
+### task\_id?
+
+> `optional` **task\_id**: `string`
+
+Task ID
+
+#### Defined in
+
+[src/types.ts:772](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L772)
+
+***
+
+### value
+
+> **value**: `number`
+
+Value of the metric
+
+#### Defined in
+
+[src/types.ts:775](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L775)

--- a/docs/types/interfaces/User.md
+++ b/docs/types/interfaces/User.md
@@ -1,0 +1,73 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / User
+
+# Interface: User
+
+User for your team
+
+## Extended by
+
+- [`AuthenticatedUser`](AuthenticatedUser.md)
+
+## Properties
+
+### email
+
+> **email**: `string`
+
+User email
+
+#### Defined in
+
+[src/types.ts:844](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L844)
+
+***
+
+### name
+
+> **name**: `null` \| `string`
+
+User name
+
+#### Defined in
+
+[src/types.ts:841](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L841)
+
+***
+
+### picture
+
+> **picture**: `null` \| `string`
+
+URL to the user's picture
+
+#### Defined in
+
+[src/types.ts:850](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L850)
+
+***
+
+### state
+
+> **state**: [`UserState`](../enumerations/UserState.md)
+
+User state
+
+#### Defined in
+
+[src/types.ts:853](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L853)
+
+***
+
+### team
+
+> **team**: `string`
+
+Team the user is associated with
+
+#### Defined in
+
+[src/types.ts:847](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L847)

--- a/docs/types/type-aliases/DatasetItemLabelUpdateData.md
+++ b/docs/types/type-aliases/DatasetItemLabelUpdateData.md
@@ -1,0 +1,15 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DatasetItemLabelUpdateData
+
+# Type Alias: DatasetItemLabelUpdateData
+
+> **DatasetItemLabelUpdateData**: \{ `explanation`: `string` \| `null`; `label`: `string` \| `number` \| `boolean`; \} \| \{ `explanation`: `string`; `label`: `string` \| `number` \| `boolean` \| `null`; \}
+
+Data to update a label
+
+## Defined in
+
+[src/types.ts:298](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L298)

--- a/docs/types/type-aliases/DeepPartial.md
+++ b/docs/types/type-aliases/DeepPartial.md
@@ -1,0 +1,17 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / DeepPartial
+
+# Type Alias: DeepPartial\<T\>
+
+> **DeepPartial**\<`T`\>: `{ [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P] }`
+
+## Type Parameters
+
+• **T**
+
+## Defined in
+
+[src/types.ts:1](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1)

--- a/docs/types/type-aliases/FilterOperatorOption.md
+++ b/docs/types/type-aliases/FilterOperatorOption.md
@@ -1,0 +1,41 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FilterOperatorOption
+
+# Type Alias: FilterOperatorOption
+
+> **FilterOperatorOption**: `object`
+
+An operator option
+
+## Type declaration
+
+### category
+
+> **category**: `"operator"`
+
+Category of the operator
+
+### label
+
+> **label**: `string`
+
+Label for the operator
+
+### supportedTypes
+
+> **supportedTypes**: `string`[]
+
+Types supported by the operator
+
+### value
+
+> **value**: [`FilterOperator`](../enumerations/FilterOperator.md)
+
+Value of the operator
+
+## Defined in
+
+[src/types.ts:527](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L527)

--- a/docs/types/type-aliases/FilterValueType.md
+++ b/docs/types/type-aliases/FilterValueType.md
@@ -1,0 +1,15 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FilterValueType
+
+# Type Alias: FilterValueType
+
+> **FilterValueType**: `"string"` \| `"metadata"` \| `"label"` \| `"list"`
+
+The type of a filter value
+
+## Defined in
+
+[src/types.ts:544](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L544)

--- a/docs/types/type-aliases/FinetunedModelCreateOptions.md
+++ b/docs/types/type-aliases/FinetunedModelCreateOptions.md
@@ -1,0 +1,15 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / FinetunedModelCreateOptions
+
+# Type Alias: FinetunedModelCreateOptions
+
+> **FinetunedModelCreateOptions**: `Pick`\<[`LabelingModel`](../interfaces/LabelingModel.md), `"augmented_finetuning_model"` \| `"base_model"` \| `"comparison_model"` \| `"datasets"` \| `"hyperparameters"` \| `"lora"` \| `"project_id"` \| `"task_id"`\>
+
+Options for creating a finetuned model
+
+## Defined in
+
+[src/types.ts:1267](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1267)

--- a/docs/types/type-aliases/IntegrationConfig.md
+++ b/docs/types/type-aliases/IntegrationConfig.md
@@ -1,0 +1,15 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / IntegrationConfig
+
+# Type Alias: IntegrationConfig
+
+> **IntegrationConfig**: `Record`\<`string`, `string` \| `null`\>
+
+Configuration for an integration to an external service
+
+## Defined in
+
+[src/types.ts:955](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L955)

--- a/docs/types/type-aliases/RefuelOptions.md
+++ b/docs/types/type-aliases/RefuelOptions.md
@@ -1,0 +1,33 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / RefuelOptions
+
+# Type Alias: RefuelOptions
+
+> **RefuelOptions**: `Pick`\<[`RequestOptions`](../interfaces/RequestOptions.md)\<`unknown`\>, `"retries"` \| `"initialRetryTimeout"` \| `"maxRetries"` \| `"retryStatusCodes"`\> & `object`
+
+Options to initialize a Refuel client
+
+## Type declaration
+
+### apiKey?
+
+> `optional` **apiKey**: `string`
+
+Refuel API key
+
+#### See
+
+https://app.refuel.ai/settings
+
+### baseUrl?
+
+> `optional` **baseUrl**: `string`
+
+Origin to send requests to
+
+## Defined in
+
+[src/types.ts:35](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L35)

--- a/docs/types/type-aliases/SortDirection.md
+++ b/docs/types/type-aliases/SortDirection.md
@@ -1,0 +1,13 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / SortDirection
+
+# Type Alias: SortDirection
+
+> **SortDirection**: `"ascending"` \| `"descending"`
+
+## Defined in
+
+[src/types.ts:569](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L569)

--- a/docs/types/type-aliases/TaskRunStatus.md
+++ b/docs/types/type-aliases/TaskRunStatus.md
@@ -1,0 +1,15 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / TaskRunStatus
+
+# Type Alias: TaskRunStatus
+
+> **TaskRunStatus**: `"restarted"` \| `"not_started"` \| `"active"` \| `"completed"` \| `"failed"` \| `"preview"` \| `"cancelled"`
+
+The status of a task run
+
+## Defined in
+
+[src/types.ts:1299](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L1299)

--- a/docs/types/type-aliases/UsageData.md
+++ b/docs/types/type-aliases/UsageData.md
@@ -1,0 +1,15 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / UsageData
+
+# Type Alias: UsageData
+
+> **UsageData**: `{ [key in UsageMetricKey]: UsageMetric[] }`
+
+Data for a telemetry metric
+
+## Defined in
+
+[src/types.ts:793](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L793)

--- a/docs/types/type-aliases/UsageMetricKey.md
+++ b/docs/types/type-aliases/UsageMetricKey.md
@@ -1,0 +1,15 @@
+[**refuel-sdk**](../../README.md)
+
+***
+
+[refuel-sdk](../../modules.md) / [types](../README.md) / UsageMetricKey
+
+# Type Alias: UsageMetricKey
+
+> **UsageMetricKey**: `"volume"` \| `"input_tokens"` \| `"output_tokens"` \| `"error_4xx"` \| `"error_5xx"` \| `"latency"` \| `"volume_web_search"`
+
+Key for a telemetry metric
+
+## Defined in
+
+[src/types.ts:781](https://github.com/refuel-ai/refuel-sdk/blob/61d30041216a525535e2edabde48af0f00ec66c9/src/types.ts#L781)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,22 @@
         "@types/node": "^22.10.2",
         "rollup": "^4.24.4",
         "rollup-plugin-typescript2": "^0.36.0",
+        "typedoc": "^0.27.5",
+        "typedoc-plugin-markdown": "^4.3.2",
+        "typedoc-plugin-md": "^0.4.3",
         "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.24.4.tgz",
+      "integrity": "sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^1.24.2",
+        "@shikijs/types": "^1.24.2",
+        "@shikijs/vscode-textmate": "^9.3.1"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -351,10 +366,109 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.2.tgz",
+      "integrity": "sha512-ZN6k//aDNWRJs1uKB12pturKHh7GejKugowOFGAuG7TxDRLod1Bd5JhpOikOiFqPmKjKEPtEA6mRCf7q3ulDyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.24.2",
+        "@shikijs/vscode-textmate": "^9.3.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.2.tgz",
+      "integrity": "sha512-bdeWZiDtajGLG9BudI0AHet0b6e7FbR0EsE4jpGaI0YwHm/XJunI9+3uZnzFtX65gsyJ6ngCIWUfA4NWRPnBkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^9.3.0",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/slugify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/transliterate": "^1.0.0",
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
+      "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true,
       "license": "MIT"
     },
@@ -375,12 +489,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -392,10 +598,67 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
     },
@@ -529,6 +792,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -552,6 +828,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -564,6 +850,24 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.12",
@@ -600,6 +904,593 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
+      "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
+      "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.3.tgz",
+      "integrity": "sha512-VXJJuNxYWSoYL6AJ6OQECCFGhIU2GGHMw8tahogePBrjkG8aCCas3ibkp7RnVOSTClg2is05/R7maAhF1XyQMg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
+      "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -681,6 +1572,49 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -810,12 +1744,79 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/typedoc": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.5.tgz",
+      "integrity": "sha512-x+fhKJtTg4ozXwKayh/ek4wxZQI/+2hmZUdO2i2NGDBRUflDble70z+ewHod3d4gRpXSO6fnlnjbDTnJk7HlkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^1.24.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.6.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.3.2.tgz",
+      "integrity": "sha512-hCF3V0axzbzGDYFW21XigWIJQBOJ2ZRVWWs7X+e62ew/pXnvz7iKF/zVdkBm3w8Mk4bmXWp/FT0IF4Zn9uBRww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.27.x"
+      }
+    },
+    "node_modules/typedoc-plugin-md": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-md/-/typedoc-plugin-md-0.4.3.tgz",
+      "integrity": "sha512-eNEEyan3GDCaDcwYCFfVEKOPMXXW1fQxVvCwOF/vNPSmVr0tty/0P738evbG4dF7ssS6rm78J3YRz94xeJaaOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/slugify": "^2.2.1",
+        "change-case": "^5.4.4",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ocavue"
+      },
+      "peerDependencies": {
+        "typedoc": "^0.27.1"
+      }
     },
     "node_modules/typescript": {
       "version": "5.6.3",
@@ -831,12 +1832,98 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -846,6 +1933,60 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "dist/index.mjs",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "docs": "typedoc --plugin typedoc-plugin-markdown --excludeInternal --out ./docs ./src/*"
   },
   "repository": {
     "type": "git",
@@ -33,6 +34,9 @@
     "@types/node": "^22.10.2",
     "rollup": "^4.24.4",
     "rollup-plugin-typescript2": "^0.36.0",
+    "typedoc": "^0.27.5",
+    "typedoc-plugin-markdown": "^4.3.2",
+    "typedoc-plugin-md": "^0.4.3",
     "typescript": "^5.6.3"
   }
 }

--- a/src/Applications/index.ts
+++ b/src/Applications/index.ts
@@ -17,6 +17,7 @@ import {
 export class Applications {
     private readonly base: RefuelBase;
 
+    /** @internal */
     constructor(base: RefuelBase) {
         this.base = base;
     }

--- a/src/DatasetExports/index.ts
+++ b/src/DatasetExports/index.ts
@@ -9,6 +9,7 @@ import { ExportDatasetOptions, ExportDatasetResponse } from "../types";
 export class DatasetExports {
     private readonly base: RefuelBase;
 
+    /** @internal */
     constructor(base: RefuelBase) {
         this.base = base;
     }

--- a/src/DatasetItems/index.ts
+++ b/src/DatasetItems/index.ts
@@ -4,6 +4,7 @@ import { Dataset, DatasetItemsOptions } from "../types";
 export class DatasetItems {
     private readonly base: RefuelBase;
 
+    /** @internal */
     constructor(base: RefuelBase) {
         this.base = base;
     }

--- a/src/Datasets/index.ts
+++ b/src/Datasets/index.ts
@@ -9,6 +9,7 @@ import { Dataset, DatasetFromList } from "../types";
 export class Datasets {
     private readonly base: RefuelBase;
 
+    /** @internal */
     constructor(base: RefuelBase) {
         this.base = base;
     }

--- a/src/FinetunedModels/index.ts
+++ b/src/FinetunedModels/index.ts
@@ -4,6 +4,7 @@ import { LabelingModel, FinetunedModelCreateOptions } from "../types";
 export class FinetunedModels {
     private base: RefuelBase;
 
+    /** @internal */
     constructor(base: RefuelBase) {
         this.base = base;
     }


### PR DESCRIPTION
`npm run docs`

this adds a markdown version of the inline docs to the `/docs` directory of this repo

We'll be able to link to this with https://github.com/refuel-ai/refuel-sdk/tree/main/docs